### PR TITLE
feat(autoconfig): offer the in-visor dmsg server and legacy HV UI in the install-page form

### DIFF
--- a/cmd/skywire/commands/autoconfig_test.go
+++ b/cmd/skywire/commands/autoconfig_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/skycoin/skywire/pkg/skywireconfig/autoconfigcmd"
 )
 
 // TestResolveConfig_ImplicitPkgEnvFallbackUnderRoot is the regression
@@ -67,5 +69,124 @@ func TestResolveConfig_ExplicitUsrEnvHonored(t *testing.T) {
 	}
 	if r.pkgEnv {
 		t.Errorf("pkgEnv = true, want false when conf has only USRENV=true")
+	}
+}
+
+// TestCollectSkyenvEdits_InVisorDmsgServer walks the whole generator
+// path for the knobs that shipped with the in-visor dmsg server
+// (#4792) and the opt-in legacy hypervisor UI: flags in, skywire.conf
+// lines out. The install-page form emits exactly this command line,
+// so a knob that renders in the form but produces no .conf line is
+// indistinguishable from the form not offering it at all.
+//
+// TRANSPORTPORT is asserted alongside DMSGSERVER on purpose — the
+// in-visor server shares the visor's transport port, so the pair is
+// what an operator actually has to get right.
+func TestCollectSkyenvEdits_InVisorDmsgServer(t *testing.T) {
+	restore := autoconfigVals
+	t.Cleanup(func() { autoconfigVals = restore })
+	autoconfigVals = autoconfigcmd.Values{}
+	cmd := autoconfigcmd.New(&autoconfigVals)
+
+	if err := cmd.ParseFlags([]string{
+		"--dmsg-server",
+		"--dmsg-server-public", "1.2.3.4:30084",
+		"--transport-port", "30084",
+		"--legacy-hv-ui",
+		"--ishv",
+	}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+
+	got := map[string]string{}
+	for _, e := range collectSkyenvEdits(cmd) {
+		got[e.Key] = e.Value
+	}
+	for key, want := range map[string]string{
+		"DMSGSERVER":       "true",
+		"DMSGSERVERPUBLIC": "'1.2.3.4:30084'",
+		"TRANSPORTPORT":    "30084",
+		"LEGACYHVUI":       "true",
+		"ISHYPERVISOR":     "true",
+	} {
+		if got[key] != want {
+			t.Errorf("%s = %q; want %q", key, got[key], want)
+		}
+	}
+
+	// And the edits land in the file the way the template expects:
+	// the commented template line is replaced in place, not appended.
+	dir := t.TempDir()
+	conf := filepath.Join(dir, "skywire.conf")
+	body := "#DMSGSERVER=true\n#DMSGSERVERPUBLIC='1.2.3.4:30084'\n#TRANSPORTPORT=0\n#LEGACYHVUI=true\n#ISHYPERVISOR=true\n"
+	if err := os.WriteFile(conf, []byte(body), 0o600); err != nil {
+		t.Fatalf("write conf: %v", err)
+	}
+	if err := updateSkyenvFile(conf, collectSkyenvEdits(cmd)); err != nil {
+		t.Fatalf("updateSkyenvFile: %v", err)
+	}
+	out, err := os.ReadFile(conf) //nolint:gosec // test-owned temp path
+	if err != nil {
+		t.Fatalf("read conf: %v", err)
+	}
+	for _, want := range []string{
+		"\nDMSGSERVER=true\n",
+		"\nDMSGSERVERPUBLIC='1.2.3.4:30084'\n",
+		"\nTRANSPORTPORT=30084\n",
+		"\nLEGACYHVUI=true\n",
+	} {
+		if !strings.Contains("\n"+string(out), want) {
+			t.Errorf("generated skywire.conf missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+// TestCollectSkyenvEdits_DmsgServerModesAreDistinct pins the two
+// in-visor dmsg-server modes apart. DMSGSERVERCONF runs a standalone
+// server config on its OWN key; DMSGSERVER runs one on the visor's
+// key. Passing the config path must not imply the boolean — config
+// gen gives the path precedence, so emitting both would hide which
+// identity the operator actually asked for.
+func TestCollectSkyenvEdits_DmsgServerModesAreDistinct(t *testing.T) {
+	restore := autoconfigVals
+	t.Cleanup(func() { autoconfigVals = restore })
+	autoconfigVals = autoconfigcmd.Values{}
+	cmd := autoconfigcmd.New(&autoconfigVals)
+
+	if err := cmd.ParseFlags([]string{"--dmsg-server-conf", "/etc/skywire-dmsg.json"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	got := map[string]string{}
+	for _, e := range collectSkyenvEdits(cmd) {
+		got[e.Key] = e.Value
+	}
+	if got["DMSGSERVERCONF"] != "'/etc/skywire-dmsg.json'" {
+		t.Errorf("DMSGSERVERCONF = %q; want %q", got["DMSGSERVERCONF"], "'/etc/skywire-dmsg.json'")
+	}
+	if _, ok := got["DMSGSERVER"]; ok {
+		t.Errorf("--dmsg-server-conf should not write DMSGSERVER; got %q", got["DMSGSERVER"])
+	}
+}
+
+// TestCollectSkyenvEdits_NoDmsgServerWritesFalse asserts the negation
+// flag turns the knob off rather than on — the classic Negate bug.
+func TestCollectSkyenvEdits_NoDmsgServerWritesFalse(t *testing.T) {
+	restore := autoconfigVals
+	t.Cleanup(func() { autoconfigVals = restore })
+	autoconfigVals = autoconfigcmd.Values{}
+	cmd := autoconfigcmd.New(&autoconfigVals)
+
+	if err := cmd.ParseFlags([]string{"--no-dmsg-server", "--no-legacy-hv-ui"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	got := map[string]string{}
+	for _, e := range collectSkyenvEdits(cmd) {
+		got[e.Key] = e.Value
+	}
+	if got["DMSGSERVER"] != "false" {
+		t.Errorf("DMSGSERVER = %q; want %q", got["DMSGSERVER"], "false")
+	}
+	if got["LEGACYHVUI"] != "false" {
+		t.Errorf("LEGACYHVUI = %q; want %q", got["LEGACYHVUI"], "false")
 	}
 }

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -83,6 +83,17 @@ type EnvMapping struct {
 	// string-typed defaults. Keep in sync — if config-gen's
 	// defaults change, update this table too.
 	Default string
+	// Note is operator-facing guidance that does not fit the flag's
+	// own one-line description because it is about how this variable
+	// interacts with ANOTHER one: a dependency ("pin TRANSPORTPORT
+	// when you turn this on") or a conflict ("this and DMSGSERVERCONF
+	// are mutually exclusive"). The install-page form renders it
+	// beside the field; the CLI does not print it, since --help
+	// already shows every flag at once and the cross-references read
+	// as noise there.
+	//
+	// Empty for the vast majority of variables, which stand alone.
+	Note string
 }
 
 // Values holds the destination addresses for every flag binding
@@ -303,17 +314,17 @@ func New(v *Values) *cobra.Command {
 	// --- Transport ports ---
 	cmd.Flags().IntVar(&v.StcprPort, "stcpr", 0, "stcp transport listening port (0 = leave unchanged, random at runtime) — writes STCPRPORT in skywire.conf")
 	cmd.Flags().IntVar(&v.SudphPort, "sudph", 0, "sudp transport listening port (0 = leave unchanged, random at runtime) — writes SUDPHPORT in skywire.conf")
-	cmd.Flags().IntVar(&v.TransportPort, "transport-port", 0, "ONE shared master port for ALL transport types — stcpr+WS on <port>/tcp, sudph+quic+wt+webrtc on <port>/udp (0 = per-type ports) — writes TRANSPORTPORT in skywire.conf")
+	cmd.Flags().IntVar(&v.TransportPort, "transport-port", 0, "ONE shared master port for ALL transport types — stcpr+WS on <port>/tcp, sudph+quic+wt+webrtc on <port>/udp, and the in-visor dmsg server when --dmsg-server is on, so pin it to a forwarded port in that case (0 = per-type ports) — writes TRANSPORTPORT in skywire.conf")
 	cmd.Flags().IntVar(&v.MinHops, "min-hops", 1, "minimum route hops — 1 = allow direct 1-hop routes, >=2 = force multihop through intermediaries for sender privacy — writes MINHOPS in skywire.conf")
 	cmd.Flags().IntVar(&v.ARTransportLimit, "ar-transport-limit", 0, "address-resolver registration: >=0 = register (default), <0 = never register (inbound-invisible). Only the sign is used; a positive value does NOT deregister after N transports — writes ARTRANSPORTLIMIT in skywire.conf")
 	cmd.Flags().BoolVar(&v.NoDirectTransports, "no-direct-transports", false, "never create direct p2p transports; dmsg relay still allowed — writes NODIRECTTRANSPORTS=true in skywire.conf")
 	cmd.Flags().BoolVar(&v.PtyRPCExec, "pty-rpc-exec", false, "allow visor-RPC-initiated dmsgpty exec (control/jump node opt-in; off closes a local privilege-escalation vector) — writes PTYRPCEXEC=true in skywire.conf")
 	cmd.Flags().IntVar(&v.LanDmsgPort, "lan-dmsg-port", 0, "LAN dmsg-server listening port (0 = leave unchanged) — writes LANDMSGPORT in skywire.conf")
 	cmd.Flags().StringVar(&v.LanDmsgPublic, "lan-dmsg-public", "", "public host:port for the LAN dmsg-server entry in dmsg discovery — writes LANDMSGPUBLIC in skywire.conf")
-	cmd.Flags().StringVar(&v.DmsgServerConf, "dmsg-server-conf", "", "standalone dmsg-server config file to run inside the visor instead of a separate unit — writes DMSGSERVERCONF in skywire.conf")
-	cmd.Flags().BoolVar(&v.DmsgServer, "dmsg-server", false, "run a dmsg server inside the visor on the visor's own key, sharing its transport port — writes DMSGSERVER in skywire.conf")
-	cmd.Flags().BoolVar(&v.NoDmsgServer, "no-dmsg-server", false, "stop running a dmsg server inside the visor — unsets DMSGSERVER in skywire.conf")
-	cmd.Flags().StringVar(&v.DmsgServerPublic, "dmsg-server-public", "", "address that in-visor dmsg server advertises (host:port) — writes DMSGSERVERPUBLIC in skywire.conf")
+	cmd.Flags().StringVar(&v.DmsgServerConf, "dmsg-server-conf", "", "run a STANDALONE dmsg-server config file inside the visor instead of a separate unit — that server keeps its OWN key, ports and wss domain, so the host publishes two discovery entries. Takes precedence over --dmsg-server — writes DMSGSERVERCONF in skywire.conf")
+	cmd.Flags().BoolVar(&v.DmsgServer, "dmsg-server", false, "run a dmsg server inside the visor on the VISOR's OWN key, sharing --transport-port (one identity, one discovery entry, one forwarded port). Pin --transport-port to a port reachable from outside. Ignored when --dmsg-server-conf is set — writes DMSGSERVER in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoDmsgServer, "no-dmsg-server", false, "stop running a dmsg server inside the visor — writes DMSGSERVER=false in skywire.conf")
+	cmd.Flags().StringVar(&v.DmsgServerPublic, "dmsg-server-public", "", "host:port the in-visor dmsg server advertises; empty advertises whatever its listener resolves to, which is only right on a LAN — writes DMSGSERVERPUBLIC in skywire.conf")
 
 	// --- Whitelists ---
 	cmd.Flags().StringVar(&v.DmsgptyPks, "dmsgpty-pks", "", "additional dmsgpty-whitelist PKs (hypervisor PKs are already implicit) — writes DMSGPTYPKS in skywire.conf")
@@ -429,15 +440,18 @@ func EnvMap() map[string]EnvMapping {
 // section comments so cross-referencing stays one-to-one.
 var envMap = map[string]EnvMapping{
 	// Hypervisor / identity
-	"hvpks":          {Key: "HYPERVISORPKS", Format: EnvFormatBashArray},
-	"ws-peer":        {Key: "WSPEERS", Format: EnvFormatBashArray},
-	"ishv":           {Key: "ISHYPERVISOR", Format: EnvFormatBool},
-	"no-ishv":        {Key: "ISHYPERVISOR", Format: EnvFormatBool, Negate: true},
-	"pk-endpoint":    {Key: "ENABLEPKENDPOINT", Format: EnvFormatBool},
-	"no-pk-endpoint": {Key: "ENABLEPKENDPOINT", Format: EnvFormatBool, Negate: true},
-	"hvaddr":         {Key: "HVHTTPADDR", Format: EnvFormatString},
-	"sk":             {Key: "SK", Format: EnvFormatString},
-	"version":        {Key: "VERSION", Format: EnvFormatString},
+	"hvpks":   {Key: "HYPERVISORPKS", Format: EnvFormatBashArray},
+	"ws-peer": {Key: "WSPEERS", Format: EnvFormatBashArray},
+	"ishv":    {Key: "ISHYPERVISOR", Format: EnvFormatBool},
+	"no-ishv": {Key: "ISHYPERVISOR", Format: EnvFormatBool, Negate: true},
+	"legacy-hv-ui": {Key: "LEGACYHVUI", Format: EnvFormatBool, Default: "false (the desk)",
+		Note: "Only affects a visor that serves the hypervisor web UI — ISHYPERVISOR=true, or enabled later with `skywire cli visor hv enable`."},
+	"no-legacy-hv-ui": {Key: "LEGACYHVUI", Format: EnvFormatBool, Negate: true, Default: "false (the desk)"},
+	"pk-endpoint":     {Key: "ENABLEPKENDPOINT", Format: EnvFormatBool},
+	"no-pk-endpoint":  {Key: "ENABLEPKENDPOINT", Format: EnvFormatBool, Negate: true},
+	"hvaddr":          {Key: "HVHTTPADDR", Format: EnvFormatString},
+	"sk":              {Key: "SK", Format: EnvFormatString},
+	"version":         {Key: "VERSION", Format: EnvFormatString},
 
 	// Visor public/private + autoconnect
 	"rewardaddr":              {Key: "REWARDSKYADDR", Format: EnvFormatString},
@@ -457,9 +471,24 @@ var envMap = map[string]EnvMapping{
 	// Transport ports. 0 = OS-assigned random port at runtime;
 	// stays unchanged across visor restarts only when pinned to a
 	// non-zero value.
-	"stcpr":          {Key: "STCPRPORT", Format: EnvFormatInt, Default: "0 (random)"},
-	"sudph":          {Key: "SUDPHPORT", Format: EnvFormatInt, Default: "0 (random)"},
-	"transport-port": {Key: "TRANSPORTPORT", Format: EnvFormatInt, Default: "0 (per-type ports)"},
+	"stcpr": {Key: "STCPRPORT", Format: EnvFormatInt, Default: "0 (random)"},
+	"sudph": {Key: "SUDPHPORT", Format: EnvFormatInt, Default: "0 (random)"},
+	"transport-port": {Key: "TRANSPORTPORT", Format: EnvFormatInt, Default: "0 (per-type ports)",
+		Note: "Pin this to a forwarded, externally reachable port when DMSGSERVER is on: the in-visor dmsg server serves its peers on this same port, so a random one leaves it unreachable."},
+
+	// In-visor dmsg server. Two mutually exclusive modes, and the
+	// distinction matters because they produce different identities:
+	// DMSGSERVER runs on the VISOR's key (one entry, both roles),
+	// DMSGSERVERCONF runs a standalone server config on that file's
+	// OWN key (two entries). gen.go gives the config path precedence
+	// when an operator somehow sets both.
+	"dmsg-server-conf": {Key: "DMSGSERVERCONF", Format: EnvFormatString,
+		Note: "Runs a standalone dmsg-server config file inside the visor, on that file's OWN key and ports. Takes precedence over DMSGSERVER. Stop and disable the separate dmsg server unit first."},
+	"dmsg-server": {Key: "DMSGSERVER", Format: EnvFormatBool, Default: "false",
+		Note: "Runs the dmsg server on the VISOR's own key, sharing TRANSPORTPORT — pin TRANSPORTPORT to a reachable port. Ignored when DMSGSERVERCONF is set."},
+	"no-dmsg-server": {Key: "DMSGSERVER", Format: EnvFormatBool, Negate: true, Default: "false"},
+	"dmsg-server-public": {Key: "DMSGSERVERPUBLIC", Format: EnvFormatString,
+		Note: "host:port the DMSGSERVER entry advertises. Empty advertises whatever the listener resolves to, which is only right on a LAN."},
 
 	// Privacy / routing knobs.
 	"min-hops":             {Key: "MINHOPS", Format: EnvFormatInt, Default: "1"},

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go
@@ -12,25 +12,34 @@ import (
 var allFlags = []string{
 	"verbose",
 	// Hypervisor / identity
-	"hvpks", "ishv", "no-ishv", "pk-endpoint", "no-pk-endpoint", "hvaddr", "sk", "version",
+	"hvpks", "ws-peer", "ishv", "no-ishv", "legacy-hv-ui", "no-legacy-hv-ui",
+	"pk-endpoint", "no-pk-endpoint", "hvaddr", "sk", "version",
 	// Visor public/private + autoconnect
 	"rewardaddr", "public", "no-public", "publicip", "disable-public-autoconn",
 	// Service discovery / deployment
 	"testenv", "url", "svcconf", "minsess", "maxtransports", "stun",
-	// Transport ports
-	"stcpr", "sudph", "transport-port", "lan-dmsg-port", "lan-dmsg-public",
+	// Transport ports + privacy/routing knobs
+	"stcpr", "sudph", "transport-port", "min-hops", "ar-transport-limit",
+	"no-direct-transports", "pty-rpc-exec", "lan-dmsg-port", "lan-dmsg-public",
+	"dmsg-server-conf", "dmsg-server", "no-dmsg-server", "dmsg-server-public",
 	// Whitelists
 	"dmsgpty-pks", "survey", "routesetup", "tpsetup",
 	// Route calculation
 	"calculate-routes",
 	// VPN server
-	"vpnserver", "no-vpnserver", "vpnrouter", "vpnrouter-lan-ifc", "killsw", "addvpn", "vpnwl", "secure", "netifc",
+	"vpnserver", "no-vpnserver", "vpnrouter", "vpnrouter-lan-ifc", "vpnrouter-subnet",
+	"vpnrouter-wifi", "vpnrouter-ssid", "vpnrouter-passphrase", "vpnrouter-band",
+	"vpnrouter-channel", "vpnrouter-country", "vpnrouter-open", "vpnrouter-mesh-gateway",
+	"vpnrouter-mesh-gateway-cidr", "vpnrouter-mesh-gateway-tls",
+	"killsw", "addvpn", "vpnwl", "secure", "netifc",
 	// Proxy
 	"proxyserver", "no-proxyserver", "proxyclientpk", "startproxyclient", "proxywl",
 	// SOCKS5 web bridges
-	"dmsgweb", "no-dmsgweb", "skynetweb", "no-skynetweb", "dmsgweb-upstream", "skynetweb-upstream",
+	"dmsgweb", "no-dmsgweb", "skynetweb", "no-skynetweb", "dmsgweb-upstream",
+	"skynetweb-upstream", "dmsgweb-addr", "skynetweb-addr",
 	// Skychat
-	"skychat", "no-skychat", "chataddr", "servechatpair", "no-servechatpair",
+	"skychat", "no-skychat", "chataddr", "chatportless", "no-chatportless",
+	"servechatpair", "no-servechatpair",
 	// Skymail bridge
 	"skymail-bridge", "no-skymail-bridge",
 	// Skycoin daemon
@@ -59,6 +68,9 @@ var negationPairs = []struct {
 	pos, neg string
 }{
 	{"ishv", "no-ishv"},
+	{"legacy-hv-ui", "no-legacy-hv-ui"},
+	{"dmsg-server", "no-dmsg-server"},
+	{"chatportless", "no-chatportless"},
 	{"pk-endpoint", "no-pk-endpoint"},
 	{"public", "no-public"},
 	{"vpnserver", "no-vpnserver"},
@@ -232,5 +244,61 @@ func TestNew_UsageString_RendersWithoutError(t *testing.T) {
 		if !strings.Contains(usage, "--"+name) {
 			t.Errorf("UsageString missing --%s", name)
 		}
+	}
+}
+
+// TestEnvMap_InVisorDmsgServerAndLegacyUI pins the env mappings for
+// the knobs that shipped with the in-visor dmsg server (#4792) and
+// the opt-in legacy hypervisor UI. Their flags were registered and
+// autoconfig wrote them, but envMap had no entries — so the
+// install-page form, which renders from this table, could not offer
+// them at all. Assert the exact SKYENV names and encodings, because
+// a typo here is invisible until an operator's generated
+// skywire.conf silently fails to change anything.
+func TestEnvMap_InVisorDmsgServerAndLegacyUI(t *testing.T) {
+	m := EnvMap()
+	want := map[string]EnvMapping{
+		"legacy-hv-ui":       {Key: "LEGACYHVUI", Format: EnvFormatBool},
+		"no-legacy-hv-ui":    {Key: "LEGACYHVUI", Format: EnvFormatBool, Negate: true},
+		"dmsg-server":        {Key: "DMSGSERVER", Format: EnvFormatBool},
+		"no-dmsg-server":     {Key: "DMSGSERVER", Format: EnvFormatBool, Negate: true},
+		"dmsg-server-public": {Key: "DMSGSERVERPUBLIC", Format: EnvFormatString},
+		"dmsg-server-conf":   {Key: "DMSGSERVERCONF", Format: EnvFormatString},
+	}
+	for flag, w := range want {
+		got, ok := m[flag]
+		if !ok {
+			t.Errorf("envMap missing --%s", flag)
+			continue
+		}
+		if got.Key != w.Key {
+			t.Errorf("--%s Key = %q; want %q", flag, got.Key, w.Key)
+		}
+		if got.Format != w.Format {
+			t.Errorf("--%s Format = %q; want %q", flag, got.Format, w.Format)
+		}
+		if got.Negate != w.Negate {
+			t.Errorf("--%s Negate = %v; want %v", flag, got.Negate, w.Negate)
+		}
+	}
+}
+
+// TestEnvMap_TransportPortDependencyNoted asserts the cross-field
+// guidance survives: the in-visor dmsg server shares TRANSPORTPORT,
+// so a random port leaves it unreachable from outside. The page has
+// no other way to learn that these two fields are coupled, and the
+// two dmsg-server modes are easy to confuse, so each carries a Note.
+func TestEnvMap_TransportPortDependencyNoted(t *testing.T) {
+	m := EnvMap()
+	for _, flag := range []string{"transport-port", "dmsg-server", "dmsg-server-conf", "dmsg-server-public"} {
+		if m[flag].Note == "" {
+			t.Errorf("--%s should carry a Note explaining its cross-field dependency", flag)
+		}
+	}
+	if !strings.Contains(m["transport-port"].Note, "DMSGSERVER") {
+		t.Errorf("--transport-port Note should name DMSGSERVER; got %q", m["transport-port"].Note)
+	}
+	if !strings.Contains(m["dmsg-server"].Note, "DMSGSERVERCONF") {
+		t.Errorf("--dmsg-server Note should say DMSGSERVERCONF wins; got %q", m["dmsg-server"].Note)
 	}
 }


### PR DESCRIPTION
The install-command generator builds its form from `autoconfigcmd.EnvMap()`, the flag → `skywire.conf` variable table. `--legacy-hv-ui`, `--dmsg-server`, `--no-dmsg-server`, `--dmsg-server-public` and `--dmsg-server-conf` were registered as flags and written by `collectSkyenvEdits`, but never added to that table — so the generator had no `LEGACYHVUI`, `DMSGSERVER`, `DMSGSERVERPUBLIC` or `DMSGSERVERCONF` field to offer, and an operator could not generate a config that uses the visor+dmsg-server combination from #4792.

This adds the six entries, plus a `Note` field for guidance that spans two variables and so cannot fit in a one-line flag description: the in-visor dmsg server shares `TRANSPORTPORT`, so that port has to be pinned to one actually reachable from outside; and `DMSGSERVER` (server on the visor's OWN key, one identity, one entry) and `DMSGSERVERCONF` (a standalone server config on that file's own key) are mutually exclusive, with the config path winning in `gen.go`. The flag descriptions now say the same, since the form renders those too.

The test's canonical flag list had drifted by about thirty flags, which is why CI never caught the gap; it is filled in, and new tests assert the generated `skywire.conf` lines end to end. Not exposed here, and worth a follow-up: `routing.no_transit` (#4788) and `dmsg.relay_max_streams` (#4789) are config keys with no SKYENV variable, and `config gen` reads none, so there is nothing for the env-var-only generator to write yet.