### PR TITLE
fix(dmsg,transport): stop discarding the reason a dial failed

### DIFF
--- a/cmd/skywire-cli/commands/dmsg/probe.go
+++ b/cmd/skywire-cli/commands/dmsg/probe.go
@@ -162,20 +162,20 @@ Examples:
 		}
 
 		start := time.Now()
-		reachable, err := rpcProbeOne(rpcClient, pk, uint16(port))
+		reachable, reason, err := rpcProbeOne(rpcClient, pk, uint16(port))
 		latency := time.Since(start)
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("probe failed: %w", err))
 		}
 
-		emitProbeResult(cmd, pk, uint16(port), reachable, latency)
+		emitProbeResult(cmd, pk, uint16(port), reachable, reason, latency)
 	},
 }
 
 // emitProbeResult prints one single-port probe result, honoring the
 // global --json flag (the multi-port sweep already does). Keeps the
 // human line identical to what the command has always printed.
-func emitProbeResult(cmd *cobra.Command, pk cipher.PubKey, port uint16, reachable bool, latency time.Duration) {
+func emitProbeResult(cmd *cobra.Command, pk cipher.PubKey, port uint16, reachable bool, reason string, latency time.Duration) {
 	scheme, suffix := probeSchemeSuffix()
 	if jsonMode, _ := cmd.Flags().GetBool(internal.JSONString); jsonMode { //nolint:errcheck
 		b, _ := json.MarshalIndent(struct { //nolint:errcheck
@@ -185,7 +185,8 @@ func emitProbeResult(cmd *cobra.Command, pk cipher.PubKey, port uint16, reachabl
 			Server    string `json:"server,omitempty"`
 			Reachable bool   `json:"reachable"`
 			LatencyMS int64  `json:"latency_ms"`
-		}{pk.String(), port, scheme, probeServer, reachable, latency.Milliseconds()}, "", "  ")
+			Reason    string `json:"reason,omitempty"`
+		}{pk.String(), port, scheme, probeServer, reachable, latency.Milliseconds(), reason}, "", "  ")
 		fmt.Println(string(b))
 		return
 	}
@@ -193,26 +194,42 @@ func emitProbeResult(cmd *cobra.Command, pk cipher.PubKey, port uint16, reachabl
 	if reachable {
 		state = "reachable"
 	}
+	if !reachable && reason != "" {
+		fmt.Printf("%s://%s:%d%s — %s (%s): %s\n", scheme, pk, port, suffix, state, latency.Round(time.Millisecond), reason)
+		return
+	}
 	fmt.Printf("%s://%s:%d%s — %s (%s)\n", scheme, pk, port, suffix, state, latency.Round(time.Millisecond))
 }
 
 // rpcProbeOne dispatches a single RPC-mode probe by the selected transport.
+// The reason is "" for the transports that have no reason-carrying RPC, and
+// for a visor too old to serve DmsgProbeReason — in both cases the result is
+// still the plain reachable/unreachable answer, as before.
 func rpcProbeOne(rpcClient interface {
 	DmsgProbe(cipher.PubKey, uint16) (bool, error)
+	DmsgProbeReason(cipher.PubKey, uint16) (bool, string, error)
 	DmsgProbeViaServer(cipher.PubKey, uint16, cipher.PubKey) (bool, error)
 	SkynetProbe(cipher.PubKey, uint16) (bool, error)
-}, pk cipher.PubKey, port uint16) (bool, error) {
+}, pk cipher.PubKey, port uint16) (bool, string, error) {
 	if probeSkynet {
-		return rpcClient.SkynetProbe(pk, port)
+		reachable, err := rpcClient.SkynetProbe(pk, port)
+		return reachable, "", err
 	}
 	if probeServer != "" {
 		srv, err := parsePK(probeServer)
 		if err != nil {
-			return false, fmt.Errorf("invalid --server pk: %w", err)
+			return false, "", fmt.Errorf("invalid --server pk: %w", err)
 		}
-		return rpcClient.DmsgProbeViaServer(pk, port, srv)
+		reachable, err := rpcClient.DmsgProbeViaServer(pk, port, srv)
+		return reachable, "", err
 	}
-	return rpcClient.DmsgProbe(pk, port)
+	reachable, reason, err := rpcClient.DmsgProbeReason(pk, port)
+	if err != nil && strings.Contains(err.Error(), "can't find method") {
+		// Visor predates DmsgProbeReason — fall back to the boolean probe.
+		reachable, err = rpcClient.DmsgProbe(pk, port)
+		return reachable, "", err
+	}
+	return reachable, reason, err
 }
 
 // probeSchemeSuffix returns the URL scheme + an optional suffix for the
@@ -270,6 +287,10 @@ func runTCPProbe(cmd *cobra.Command) {
 	conn, err := tcpnoise.Dial(ctx, hostPort, myPK, mySK, rPK)
 	latency := time.Since(start)
 	reachable := err == nil
+	var reason string
+	if err != nil {
+		reason = err.Error()
+	}
 	if conn != nil {
 		_ = conn.Close() //nolint:errcheck
 	}
@@ -280,7 +301,8 @@ func runTCPProbe(cmd *cobra.Command) {
 			Addr      string `json:"addr"`
 			Reachable bool   `json:"reachable"`
 			LatencyMS int64  `json:"latency_ms"`
-		}{rPK.String(), "tcp", hostPort, reachable, latency.Milliseconds()}, "", "  ")
+			Reason    string `json:"reason,omitempty"`
+		}{rPK.String(), "tcp", hostPort, reachable, latency.Milliseconds(), reason}, "", "  ")
 		fmt.Println(string(b))
 		return
 	}
@@ -420,10 +442,13 @@ func runMultiPortProbeRPC(cmd *cobra.Command, pk cipher.PubKey, ports []uint16, 
 			defer wg.Done()
 			defer func() { <-sem }()
 			start := time.Now()
-			reachable, perr := rpcProbeOne(rpcClient, pk, p)
+			reachable, reason, perr := rpcProbeOne(rpcClient, pk, p)
 			results[i] = portProbeResult{Port: p, Reachable: reachable && perr == nil, Latency: time.Since(start)}
-			if perr != nil {
+			switch {
+			case perr != nil:
 				results[i].Err = perr.Error()
+			case !reachable:
+				results[i].Err = reason
 			}
 		}()
 	}
@@ -464,12 +489,15 @@ func runMultiPortProbeStandalone(cmd *cobra.Command, pk cipher.PubKey, ports []u
 			defer func() { <-sem }()
 			start := time.Now()
 			var reachable bool
+			var reason string
 			if serverSet {
 				reachable = dmsgC.ProbeViaServer(ctx, pk, p, serverPK)
+			} else if perr := dmsgC.ProbeErr(ctx, pk, p); perr != nil {
+				reason = perr.Error()
 			} else {
-				reachable = dmsgC.Probe(ctx, pk, p)
+				reachable = true
 			}
-			results[i] = portProbeResult{Port: p, Reachable: reachable, Latency: time.Since(start)}
+			results[i] = portProbeResult{Port: p, Reachable: reachable, Latency: time.Since(start), Err: reason}
 		}()
 	}
 	wg.Wait()
@@ -502,12 +530,15 @@ func runStandaloneProbe(cmd *cobra.Command, pk cipher.PubKey, port uint16) {
 
 	start := time.Now()
 	var reachable bool
+	var reason string
 	if serverSet {
 		reachable = dmsgC.ProbeViaServer(ctx, pk, port, serverPK)
+	} else if perr := dmsgC.ProbeErr(ctx, pk, port); perr != nil {
+		reason = perr.Error()
 	} else {
-		reachable = dmsgC.Probe(ctx, pk, port)
+		reachable = true
 	}
 	latency := time.Since(start)
 
-	emitProbeResult(cmd, pk, port, reachable, latency)
+	emitProbeResult(cmd, pk, port, reachable, reason, latency)
 }

--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -1372,12 +1372,22 @@ func (ce *Client) DiscEntry(ctx context.Context, pk cipher.PubKey) (*disc.Entry,
 // route setup: if Probe fails, the destination is unreachable and there
 // is no point attempting a full route setup that will time out.
 func (ce *Client) Probe(ctx context.Context, pk cipher.PubKey, port uint16) bool {
+	return ce.ProbeErr(ctx, pk, port) == nil
+}
+
+// ProbeErr is Probe with the reason kept. Probe answers only "reachable or
+// not", which makes an unreachable result undiagnosable: the caller cannot
+// tell a destination with no listener on that port from one whose dmsg
+// server stopped listening from a dial that ran out of budget. Every one of
+// those reads as a bare "no" in `skywire cli dmsg probe`'s output, whose
+// ERROR column was consequently always empty.
+func (ce *Client) ProbeErr(ctx context.Context, pk cipher.PubKey, port uint16) error {
 	stream, err := ce.DialStream(ctx, Addr{PK: pk, Port: port})
 	if err != nil {
-		return false
+		return err
 	}
 	_ = stream.Close() //nolint:errcheck
-	return true
+	return nil
 }
 
 // ProbeViaServer is like Probe but forces the stream through a specific

--- a/pkg/dmsg/dmsg/client_dial.go
+++ b/pkg/dmsg/dmsg/client_dial.go
@@ -41,13 +41,26 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 		return nil, failErr
 	}
 
+	// lastCause carries the most informative per-attempt failure seen while
+	// walking the dial ladder. Every phase has a specific reason for failing
+	// (a destination with no listener, a server that cannot forward, a
+	// refused TCP connection) and the ladder then collapses all of them into
+	// ErrCannotConnectToDelegated. Returning that bare code told operators
+	// only that everything failed, never why: a --direct dial that died
+	// because the destination's dmsg server had stopped listening reported
+	// "cannot connect to delegated server", which reads as a problem with
+	// the delegated servers themselves. Carry the cause out with the code.
+	var lastCause error
+
 	// Relay first. The visor nominated these peers to carry this client's dmsg
 	// traffic, and a relay resolves the destination and forwards to its servers
 	// itself — so it goes before the discovery lookup (the deployment services
 	// have no client entry and would otherwise take the connected-servers
 	// fallback), before the cached route, and before any server session.
 	if relaySessions := ce.sortedRelaySessions(); len(relaySessions) > 0 && !ce.relayDialSkipped(addr.PK) {
-		if stream, ok := ce.sequentialPhaseDial(ctx, addr, relaySessions, len(relaySessions)); ok {
+		stream, ok, cause := ce.sequentialPhaseDial(ctx, addr, relaySessions, len(relaySessions))
+		noteDialCause(&lastCause, cause)
+		if ok {
 			ce.dialFailClear(addr.PK)
 			return stream, nil
 		}
@@ -153,7 +166,9 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 	// dials to produce consecutive, usable streams (the exact failure
 	// mode of TestMultiServerStreams).
 	delegatedSessions := ce.sortedDelegatedSessions(entry.Client.DelegatedServers)
-	if stream, ok := ce.sequentialPhaseDial(ctx, addr, delegatedSessions, maxPerExistingPhase); ok {
+	stream, ok, cause := ce.sequentialPhaseDial(ctx, addr, delegatedSessions, maxPerExistingPhase)
+	noteDialCause(&lastCause, cause)
+	if ok {
 		ce.dialFailClear(addr.PK)
 		return stream, nil
 	}
@@ -163,7 +178,9 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 	// forwards the request to the target's server. Sorted by latency.
 	// Skips negative-cached pairs.
 	meshSessions := ce.sortedMeshSessions(entry.Client.DelegatedServers)
-	if stream, ok := ce.sequentialPhaseDial(ctx, addr, meshSessions, maxPerExistingPhase); ok {
+	stream, ok, cause = ce.sequentialPhaseDial(ctx, addr, meshSessions, maxPerExistingPhase)
+	noteDialCause(&lastCause, cause)
+	if ok {
 		ce.dialFailClear(addr.PK)
 		return stream, nil
 	}
@@ -175,12 +192,14 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 		}
 		dSes, err := ce.EnsureAndObtainSession(ctx, srvPK)
 		if err != nil {
+			noteDialCause(&lastCause, err)
 			continue
 		}
 		stream, err := dSes.DialStream(ctx, addr)
 		if err != nil {
 			ce.log.WithError(err).WithField("server", srvPK).
 				Debug("DialStream failed via new session, trying next server")
+			noteDialCause(&lastCause, err)
 			continue
 		}
 		ce.setCachedRoute(addr.PK, srvPK)
@@ -201,9 +220,31 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 	// out (its short deadline says nothing about the destination — recording
 	// it would fast-fail other callers with healthy budgets).
 	if ctx.Err() == nil {
-		ce.dialFailRecord(addr.PK, ErrCannotConnectToDelegated)
+		ce.dialFailRecord(addr.PK, dialLadderErr(lastCause))
 	}
-	return nil, ErrCannotConnectToDelegated
+	return nil, dialLadderErr(lastCause)
+}
+
+// noteDialCause keeps the FIRST non-nil per-attempt failure seen while
+// walking the dial ladder. First rather than last: the earliest phase is
+// the one whose sessions were most likely to be the right path, so its
+// reason describes the destination better than a later phase's does.
+func noteDialCause(dst *error, cause error) {
+	if dst == nil || cause == nil || *dst != nil {
+		return
+	}
+	*dst = cause
+}
+
+// dialLadderErr is what a fully-exhausted dial ladder returns: the same 202
+// code every caller already matches on, carrying the per-attempt cause so
+// the reason is not lost. errors.Is(err, ErrCannotConnectToDelegated) still
+// holds — Error.Is matches on the code, not on the wrapped chain.
+func dialLadderErr(cause error) error {
+	if cause == nil {
+		return ErrCannotConnectToDelegated
+	}
+	return ErrCannotConnectToDelegated.Wrap(cause)
 }
 
 // getClientEntryCached returns a client entry. Resolution order:
@@ -270,14 +311,15 @@ func (ce *Client) getClientEntryCached(ctx context.Context, clientPK cipher.PubK
 // orphan streams in the destination's accept queue after cancellation
 // — same failure mode but from a different angle (the exact failure
 // mode of TestMultiServerStreams).
-func (ce *Client) sequentialPhaseDial(ctx context.Context, addr Addr, sessions []ClientSession, cap int) (*Stream, bool) {
+func (ce *Client) sequentialPhaseDial(ctx context.Context, addr Addr, sessions []ClientSession, cap int) (*Stream, bool, error) {
 	tried := 0
+	var cause error
 	for _, s := range sessions {
 		if tried >= cap {
 			break
 		}
 		if ctx.Err() != nil {
-			return nil, false
+			return nil, false, cause
 		}
 		tried++
 
@@ -285,12 +327,13 @@ func (ce *Client) sequentialPhaseDial(ctx context.Context, addr Addr, sessions [
 		if err != nil {
 			ce.log.WithError(err).WithField("server", s.RemotePK()).
 				Debug("DialStream failed, trying next session")
+			noteDialCause(&cause, err)
 			continue
 		}
 		ce.setCachedRoute(addr.PK, s.RemotePK())
-		return stream, true
+		return stream, true, nil
 	}
-	return nil, false
+	return nil, false, cause
 }
 
 // sortedDelegatedSessions returns existing sessions to the given delegated servers,

--- a/pkg/dmsg/dmsg/dial_cause_test.go
+++ b/pkg/dmsg/dmsg/dial_cause_test.go
@@ -1,0 +1,52 @@
+// Package dmsg pkg/dmsg/dmsg/dial_cause_test.go c1-net-dmsg
+package dmsg
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDialLadderErrKeepsCodeAndCause(t *testing.T) {
+	t.Run("no cause returns the bare sentinel", func(t *testing.T) {
+		err := dialLadderErr(nil)
+		require.ErrorIs(t, err, ErrCannotConnectToDelegated)
+		require.Equal(t, ErrCannotConnectToDelegated.Error(), err.Error())
+	})
+
+	t.Run("a cause is carried without breaking errors.Is", func(t *testing.T) {
+		err := dialLadderErr(ErrReqNoListener)
+		// The 202 code every caller matches on still matches.
+		require.ErrorIs(t, err, ErrCannotConnectToDelegated)
+		// And the reason is now reachable, both textually and by errors.Is.
+		require.ErrorIs(t, err, ErrReqNoListener)
+		require.True(t, strings.Contains(err.Error(), "no associated listener"),
+			"cause should be visible in the message, got %q", err.Error())
+	})
+
+	t.Run("a non-dmsg cause is carried too", func(t *testing.T) {
+		cause := errors.New("connect: connection refused")
+		err := dialLadderErr(cause)
+		require.ErrorIs(t, err, ErrCannotConnectToDelegated)
+		require.True(t, strings.Contains(err.Error(), "connection refused"))
+	})
+}
+
+func TestErrorIsMatchesOnCodeOnly(t *testing.T) {
+	// Wrapping must not defeat sentinel matching: Error is a comparable
+	// struct, so without Error.Is the wrapped value would compare unequal.
+	require.ErrorIs(t, ErrReqNoListener.Wrap(errors.New("x")), ErrReqNoListener)
+	require.NotErrorIs(t, ErrReqNoListener, ErrCannotConnectToDelegated)
+}
+
+func TestNoteDialCauseKeepsTheFirst(t *testing.T) {
+	var got error
+	first := errors.New("first")
+	noteDialCause(&got, nil)
+	require.NoError(t, got)
+	noteDialCause(&got, first)
+	noteDialCause(&got, errors.New("second"))
+	require.Equal(t, first, got)
+}

--- a/pkg/dmsg/dmsg/errors.go
+++ b/pkg/dmsg/dmsg/errors.go
@@ -116,3 +116,18 @@ func (e Error) Wrap(err error) Error {
 	e.nxt = err
 	return e
 }
+
+// Is reports whether target is the same dmsg error, comparing the code
+// alone. Without it, wrapping (Error.Wrap, used by dialLadderErr to carry
+// the per-attempt cause behind a 202) would defeat every
+// errors.Is(err, dmsg.ErrX) check in the tree: Error is a comparable
+// struct, so the default equality also compares the wrapped `nxt` and a
+// wrapped error would no longer match its own sentinel.
+func (e Error) Is(target error) bool {
+	t, ok := target.(Error)
+	return ok && e.code == t.code
+}
+
+// Unwrap exposes the wrapped cause so errors.Is/As can also reach past a
+// dmsg error to what actually failed underneath it.
+func (e Error) Unwrap() error { return e.nxt }

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -1096,7 +1096,14 @@ func (tm *Manager) EnsureBestTransport(ctx context.Context, remote cipher.PubKey
 			return nil
 		}
 	}
-	var lastErr error
+	// Collect EVERY type's failure, not just the last one. The preference
+	// order is walked to the end, so keeping only lastErr reported whichever
+	// type happened to sort last and silently dropped the rest — an
+	// on-demand --direct dial where all five types failed identically at
+	// address resolution surfaced as "webrtc: dial signaling: ..." alone,
+	// which reads as a webrtc-specific problem and hides that stcpr, sudph,
+	// squicr and swtr died the same way one line earlier.
+	var attemptErrs []error
 	for _, nt := range order {
 		if skipSet[nt] {
 			continue
@@ -1114,7 +1121,7 @@ func (tm *Manager) EnsureBestTransport(ctx context.Context, remote cipher.PubKey
 		if ctx.Err() != nil { // parent canceled (not just this type's per-type cap) → abort
 			return ctx.Err()
 		}
-		lastErr = err
+		attemptErrs = append(attemptErrs, fmt.Errorf("%s: %w", nt, err))
 	}
 	// Last resort: the DMSG relay — loud, because it means no direct type worked.
 	// Callers can opt OUT by passing types.DMSG in `skip`. The js build opts out
@@ -1126,11 +1133,11 @@ func (tm *Manager) EnsureBestTransport(ctx context.Context, remote cipher.PubKey
 		if _, err := tm.SaveTransport(ctx, remote, types.DMSG, LabelAutomatic); err == nil {
 			tm.Logger.Warnf("auto-transport: all direct types %v failed for %s — created a DMSG RELAY transport (relayed data plane; usually signals a p2p reachability problem)", order, remote)
 			return nil
-		} else if lastErr == nil {
-			lastErr = err
+		} else { //nolint:revive // the else keeps the dmsg attempt's error in the joined set
+			attemptErrs = append(attemptErrs, fmt.Errorf("%s: %w", types.DMSG, err))
 		}
 	}
-	return lastErr
+	return errors.Join(attemptErrs...)
 }
 
 // Stcpr returns stcpr client

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -257,6 +257,7 @@ type API interface {
 
 	//dmsg utilities
 	DmsgProbe(pk cipher.PubKey, port uint16) (bool, error)
+	DmsgProbeReason(pk cipher.PubKey, port uint16) (bool, string, error)
 	DmsgProbeViaServer(pk cipher.PubKey, port uint16, serverPK cipher.PubKey) (bool, error)
 	SkynetProbe(pk cipher.PubKey, port uint16) (bool, error)
 	DmsgHTTP(req DmsgHTTPRequest) (*DmsgHTTPResponse, error)

--- a/pkg/visor/api_dmsg.go
+++ b/pkg/visor/api_dmsg.go
@@ -772,6 +772,22 @@ func (v *Visor) DmsgProbe(pk cipher.PubKey, port uint16) (bool, error) {
 	return v.dmsgC.Probe(ctx, pk, port), nil
 }
 
+// DmsgProbeReason is DmsgProbe with the failure reason kept. Unreachable is
+// a result, not an RPC error, so the reason comes back as a string and the
+// error return stays reserved for the RPC itself — callers that only want
+// the boolean keep using DmsgProbe. reason is "" when reachable.
+func (v *Visor) DmsgProbeReason(pk cipher.PubKey, port uint16) (reachable bool, reason string, err error) {
+	if err := v.mustWaitDmsgReady(); err != nil {
+		return false, "", err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if perr := v.dmsgC.ProbeErr(ctx, pk, port); perr != nil {
+		return false, perr.Error(), nil
+	}
+	return true, "", nil
+}
+
 // DmsgProbeViaServer probes dmsg reachability of pk:port forced through a
 // specific dmsg server (serverPK), for per-server reachability diagnosis.
 // Returns true if reachable via that server.

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -738,6 +738,10 @@ func (proxyDefaultAPI) DmsgProbe(_ cipher.PubKey, _ uint16) (bool, error) {
 	return false, ErrProxyNotSupported
 }
 
+func (proxyDefaultAPI) DmsgProbeReason(_ cipher.PubKey, _ uint16) (bool, string, error) {
+	return false, "", ErrProxyNotSupported
+}
+
 func (proxyDefaultAPI) DmsgProbeViaServer(_ cipher.PubKey, _ uint16, _ cipher.PubKey) (bool, error) {
 	return false, ErrProxyNotSupported
 }

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -1563,6 +1563,13 @@ func (rc *rpcClient) DmsgProbe(pk cipher.PubKey, port uint16) (bool, error) {
 	return reachable, err
 }
 
+// DmsgProbeReason checks dmsg reachability and reports the failure reason.
+func (rc *rpcClient) DmsgProbeReason(pk cipher.PubKey, port uint16) (bool, string, error) {
+	var resp DmsgProbeReasonResponse
+	err := rc.Call("DmsgProbeReason", &DmsgProbeRequest{PK: pk, Port: port}, &resp)
+	return resp.Reachable, resp.Reason, err
+}
+
 // DmsgProbeViaServer checks dmsg reachability of a remote PK:port forced
 // through a specific dmsg server.
 func (rc *rpcClient) DmsgProbeViaServer(pk cipher.PubKey, port uint16, serverPK cipher.PubKey) (bool, error) {

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1271,6 +1271,11 @@ func (mc *mockRPCClient) DmsgProbe(_ cipher.PubKey, _ uint16) (bool, error) {
 	return true, nil
 }
 
+// DmsgProbeReason implements API.
+func (mc *mockRPCClient) DmsgProbeReason(_ cipher.PubKey, _ uint16) (bool, string, error) {
+	return true, "", nil
+}
+
 // DmsgProbeViaServer implements API.
 func (mc *mockRPCClient) DmsgProbeViaServer(_ cipher.PubKey, _ uint16, _ cipher.PubKey) (bool, error) {
 	return true, nil

--- a/pkg/visor/rpc_dmsg.go
+++ b/pkg/visor/rpc_dmsg.go
@@ -34,6 +34,24 @@ func (r *RPC) DmsgProbe(req *DmsgProbeRequest, out *bool) (err error) {
 	return nil
 }
 
+// DmsgProbeReasonResponse carries a probe result together with why it failed.
+type DmsgProbeReasonResponse struct {
+	Reachable bool
+	Reason    string
+}
+
+// DmsgProbeReason checks dmsg reachability and reports the failure reason.
+func (r *RPC) DmsgProbeReason(req *DmsgProbeRequest, out *DmsgProbeReasonResponse) (err error) {
+	defer rpcutil.LogCall(r.log, "DmsgProbeReason", req)(out, &err)
+
+	reachable, reason, err := r.visor.DmsgProbeReason(req.PK, req.Port)
+	if err != nil {
+		return err
+	}
+	*out = DmsgProbeReasonResponse{Reachable: reachable, Reason: reason}
+	return nil
+}
+
 // DmsgProbeViaServer probes dmsg reachability forced through a specific server.
 func (r *RPC) DmsgProbeViaServer(req *DmsgProbeViaServerRequest, out *bool) (err error) {
 	defer rpcutil.LogCall(r.log, "DmsgProbeViaServer", req)(out, &err)


### PR DESCRIPTION
Three places collapsed a specific failure into a generic one. Together they made a `proxy start --direct` failure unreadable: the dial reported a delegated-server problem when the destination's dmsg server had simply stopped listening, and the one transport type whose error happened to survive made it look webrtc-specific.

**The dial ladder** returned a bare `ErrCannotConnectToDelegated` once every phase had failed. Each phase knows exactly why it failed — no listener on that port, a server that cannot forward, a refused connection — and threw it away. It now carries the first per-attempt cause out with the 202, so the code every caller matches on is unchanged and the reason survives. `Error.Is` matches on the code alone and `Error.Unwrap` exposes the cause, so neither the wrap nor any existing `errors.Is` against a sentinel is affected (`pkg/router/map.go:40` being the one in-tree caller).

**`EnsureBestTransport`** walked the whole preference order but kept only `lastErr`. An on-demand creation where all five direct types failed identically surfaced as:

```
error="save transport: mt.client.Dial: webrtc: dial signaling: dmsg error 202"
```

when stcpr, sudph, squicr and swtr had each died one line earlier at the same address-resolver lookup. It now joins every attempt's error, labelled with its type.

**`Client.Probe`** answered only reachable-or-not, so `skywire cli dmsg probe --ports ...` could never fill its ERROR column — every unreachable port printed a bare `no`. `ProbeErr` keeps the reason, an additive `DmsgProbeReason` RPC carries it, and the CLI falls back to the boolean probe against a visor that predates it.

No behavior change beyond what is reported.

`go build .`, `go vet` and `go test` on `pkg/dmsg/dmsg`, `pkg/transport`, `pkg/visor` and `cmd/skywire-cli/...` all pass; new tests cover the wrap, the code-only `Is`, and the first-cause rule.