### PR TITLE
fix(dmsg-disc): read Entry.Timestamp in either unit it is written in

### DIFF
--- a/pkg/dmsg/discovery/store/entry_stale_test.go
+++ b/pkg/dmsg/discovery/store/entry_stale_test.go
@@ -42,3 +42,32 @@ func TestServerEntryIsStale(t *testing.T) {
 		})
 	}
 }
+
+// Entry.Timestamp is written in two units in this codebase — disc.PutEntry
+// stamps UnixNano, several constructors and tests use Unix seconds. Reading a
+// seconds value as nanoseconds dates the entry to 1970, which would withdraw a
+// live server from discovery permanently.
+func TestServerEntryStaleAcceptsBothTimestampUnits(t *testing.T) {
+	now := time.Now()
+	srv := func(ts int64) *disc.Entry {
+		return &disc.Entry{Server: &disc.Server{}, Timestamp: ts}
+	}
+
+	t.Run("fresh in nanoseconds", func(t *testing.T) {
+		require.False(t, serverEntryIsStale(srv(now.UnixNano()), now))
+	})
+	t.Run("fresh in seconds", func(t *testing.T) {
+		require.False(t, serverEntryIsStale(srv(now.Unix()), now))
+	})
+	t.Run("stale in nanoseconds", func(t *testing.T) {
+		require.True(t, serverEntryIsStale(srv(now.Add(-time.Hour).UnixNano()), now))
+	})
+	t.Run("stale in seconds", func(t *testing.T) {
+		require.True(t, serverEntryIsStale(srv(now.Add(-time.Hour).Unix()), now))
+	})
+	t.Run("the unit boundary is not a date any entry can carry", func(t *testing.T) {
+		// Just under the ceiling read as seconds is the year 33658 — far in
+		// the future, so definitively not stale either way.
+		require.False(t, serverEntryIsStale(srv(secondsTimestampCeiling-1), now))
+	})
+}

--- a/pkg/dmsg/discovery/store/redis.go
+++ b/pkg/dmsg/discovery/store/redis.go
@@ -61,7 +61,27 @@ func serverEntryIsStale(entry *disc.Entry, now time.Time) bool {
 	if entry == nil || entry.Server == nil || entry.Timestamp == 0 {
 		return false
 	}
-	return now.Sub(time.Unix(0, entry.Timestamp)) > serverEntryStaleAfter
+	return now.Sub(entryRegisteredAt(entry.Timestamp)) > serverEntryStaleAfter
+}
+
+// secondsTimestampCeiling separates the two units Entry.Timestamp is written
+// in. Anything below it cannot be a nanosecond timestamp of a real date (1e12
+// ns is 16 minutes past the epoch) and is therefore seconds; anything above it
+// cannot be seconds (1e12 s is the year 33658).
+const secondsTimestampCeiling = 1e12
+
+// entryRegisteredAt interprets Entry.Timestamp, which is written in two
+// different units in this codebase: disc.PutEntry stamps UnixNano (what every
+// production entry carries), while several entry constructors and tests use
+// Unix seconds. Guessing wrong by a factor of a billion is not a rounding
+// error — reading a seconds value as nanoseconds dates the entry to 1970, so
+// a live server would be judged stale and silently withdrawn from discovery
+// forever. Accept both rather than trusting one.
+func entryRegisteredAt(ts int64) time.Time {
+	if ts > 0 && ts < secondsTimestampCeiling {
+		return time.Unix(ts, 0)
+	}
+	return time.Unix(0, ts)
 }
 
 type redisStore struct {


### PR DESCRIPTION
#4797 judges a dmsg-server entry stale from `Entry.Timestamp` and reads it as UnixNano — what `disc.PutEntry` stamps, and what every production entry carries. Several entry constructors and tests write Unix **seconds** into the same field. Read that way round, a seconds value dates the entry to 1970, so a live server is judged stale and withdrawn from discovery permanently — the opposite of the bug #4797 set out to fix.

`TestRedisStoreServerEntry` caught it (its entry uses `time.Now().Unix()`, and `AvailableServers` returned nothing). That job passed on the previous develop run and started failing on f7bbd59e, so it is precisely this regression; the other Test-lane failures on develop pre-date it.

Interpret both units: anything below 1e12 cannot be a nanosecond timestamp of a real date (16 minutes past the epoch) and is therefore seconds; anything above cannot be seconds (the year 33658). Guessing wrong here is a factor of a billion, not a rounding error, so accept both rather than trusting one.

The redis-backed tests need a live redis and could not be run here (no redis or docker on this machine); the added `TestServerEntryStaleAcceptsBothTimestampUnits` covers the exact value shape that test uses, in both units, fresh and stale.