### PR TITLE
fix(cxosub): the feed cycle goroutine must close the channel it owns

### DIFF
--- a/pkg/cxo/cxosub/cycle_done_test.go
+++ b/pkg/cxo/cxosub/cycle_done_test.go
@@ -1,0 +1,47 @@
+// Package cxosub pkg/cxo/cxosub/cycle_done_test.go c1-net-cxo
+package cxosub
+
+import (
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// The per-feed cycle goroutine closes the channel IT owns. It used to close
+// whatever f.done happened to hold when it returned, which raced its own
+// stopper: the grace timer captures f.done, nils the field, cancels the
+// context and then waits on its captured copy. The loop therefore woke on a
+// context that was cancelled only AFTER the field had already been nilled,
+// and paniced with "close of nil channel" — taking the whole visor down, on
+// every visor, as soon as boot got far enough to acquire and release a feed.
+//
+// A panic in that goroutine kills the test binary, so this test failing looks
+// like a crash rather than an assertion failure. That is the point.
+func TestCycleLoopStopDoesNotPanicOnNilDone(t *testing.T) {
+	m := NewManager(Deps{Log: logging.MustGetLogger("cxosub-test")}, time.Millisecond)
+	m.grace = 10 * time.Millisecond
+
+	const fk = FeedTPDMetrics
+
+	m.mu.Lock()
+	m.acquireFeedLocked(fk)
+	m.mu.Unlock()
+
+	// Drop the last reference so the grace timer is armed. When it fires it
+	// nils f.done and cancels the cycle's context.
+	m.mu.Lock()
+	m.releaseFeedLocked(fk)
+	m.mu.Unlock()
+
+	// Outlast the grace timer and the cycle goroutine's unwind.
+	time.Sleep(500 * time.Millisecond)
+
+	m.mu.Lock()
+	f, ok := m.feeds[fk]
+	stopped := !ok || f.cancel == nil
+	m.mu.Unlock()
+	if !stopped {
+		t.Fatal("cycle was not stopped after the grace period")
+	}
+}

--- a/pkg/cxo/cxosub/manager.go
+++ b/pkg/cxo/cxosub/manager.go
@@ -834,8 +834,11 @@ func (m *Manager) acquireFeedLocked(fk Feed) {
 		// not called" check can't see across the timer hop.
 		ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec
 		f.cancel = cancel
-		f.done = make(chan struct{})
-		go m.cycleLoop(ctx, fk, f)
+		done := make(chan struct{})
+		f.done = done
+		// Hand the goroutine the channel it owns rather than letting it
+		// re-read f.done on the way out — see cycleLoop.
+		go m.cycleLoop(ctx, fk, f, done)
 	}
 }
 
@@ -891,8 +894,18 @@ func (m *Manager) releaseFeedLocked(fk Feed) {
 // pushes. liveServe only returns on a setup/first-Root failure; the
 // loop then retries with capped backoff so a temporarily-down publisher
 // is picked up without hammering it.
-func (m *Manager) cycleLoop(ctx context.Context, fk Feed, f *managedFeed) {
-	defer close(f.done)
+// done is the channel THIS invocation owns, passed in rather than read back
+// off f. Reading f.done on the way out raced its own stopper: the grace timer
+// captures f.done, nils the field, cancels the context and then waits on its
+// captured copy — so a loop that returned after the field was nilled paniced
+// with "close of nil channel" and left the stopper waiting on a channel
+// nothing would ever close. Releasing and re-acquiring a feed has the same
+// shape from the other side: the replacement goroutine installs a new f.done,
+// and the outgoing loop would close the newcomer's channel instead of its own,
+// making the next close a "close of closed channel". Owning the channel for
+// the lifetime of the invocation removes both.
+func (m *Manager) cycleLoop(ctx context.Context, fk Feed, f *managedFeed, done chan struct{}) {
+	defer close(done)
 	backoff := initialLiveRetry
 	for {
 		if ctx.Err() != nil {

--- a/pkg/transport/deferred_discovery.go
+++ b/pkg/transport/deferred_discovery.go
@@ -1,0 +1,209 @@
+// Package transport pkg/transport/deferred_discovery.go c2-net-transport
+//
+// DeferredDiscoveryClient lets a visor finish booting while the transport
+// discovery is unreachable.
+//
+// Constructing the real TPD client performs network I/O — an httpauth nonce
+// fetch — so it fails outright when the TPD cannot be reached. The visor used
+// to retry that construction, unbounded, on the boot path. The transport
+// module gates the visor's RPC server, its launcher (and therefore dmsgpty,
+// the hypervisor RPC and every app listener) and its router, so a visor that
+// could not reach the TPD never finished starting: alive, holding dmsg
+// sessions, answering nothing, and unmanageable for as long as the TPD stayed
+// away.
+//
+// That is a cascade, not just an outage. The deployment services are reached
+// over dmsg, so a visor co-located with them cannot register its transports
+// until they answer — and if the TPD is itself behind a visor that is stuck in
+// the same wait, neither ever proceeds. Observed in production: one host's
+// visor wedged, which took the transport discovery with it, and every visor
+// that restarted afterwards wedged the same way on the missing TPD, spreading
+// with the rollout.
+//
+// A visor's transports are useful before they are registered, and registration
+// is already retried on a timer, so the TPD is not a boot prerequisite. This
+// wrapper makes that explicit: boot proceeds with a client whose calls fail
+// cleanly until the real one connects in the background, after which every
+// call is forwarded to it.
+package transport
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// ErrDiscoveryNotReady is returned by a DeferredDiscoveryClient that has not
+// connected yet. It is deliberately distinct from a transport error: the call
+// did not fail on the wire, it never left.
+var ErrDiscoveryNotReady = errors.New("transport discovery not connected yet")
+
+// DiscoveryConnectFunc builds the real discovery client. It performs network
+// I/O and returns an error while the discovery is unreachable.
+type DiscoveryConnectFunc func(ctx context.Context) (DiscoveryClient, error)
+
+// DeferredDiscoveryClient is a DiscoveryClient that forwards to the real one
+// once it connects, and fails fast before that.
+type DeferredDiscoveryClient struct {
+	mu    sync.RWMutex
+	inner DiscoveryClient
+
+	log     *logging.Logger
+	connect DiscoveryConnectFunc
+	ready   chan struct{}
+	once    sync.Once
+}
+
+// NewDeferredDiscoveryClient returns a client that is not connected yet and a
+// goroutine that keeps trying to connect until ctx ends. interval bounds how
+// often connection is attempted.
+func NewDeferredDiscoveryClient(ctx context.Context, log *logging.Logger, interval time.Duration, connect DiscoveryConnectFunc) *DeferredDiscoveryClient {
+	d := &DeferredDiscoveryClient{
+		log:     log,
+		connect: connect,
+		ready:   make(chan struct{}),
+	}
+	go d.connectLoop(ctx, interval)
+	return d
+}
+
+// Ready is closed once the real client is connected.
+func (d *DeferredDiscoveryClient) Ready() <-chan struct{} { return d.ready }
+
+// Connected reports whether the real client is in place.
+func (d *DeferredDiscoveryClient) Connected() bool {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.inner != nil
+}
+
+func (d *DeferredDiscoveryClient) connectLoop(ctx context.Context, interval time.Duration) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		client, err := d.connect(ctx)
+		if err == nil {
+			d.mu.Lock()
+			d.inner = client
+			d.mu.Unlock()
+			d.once.Do(func() { close(d.ready) })
+			d.log.Info("Transport discovery connected; transports will register from here on")
+			return
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		d.log.WithError(err).Debug("Transport discovery still unreachable; the visor runs without it and keeps retrying")
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+		}
+	}
+}
+
+// client returns the real client, or ErrDiscoveryNotReady.
+func (d *DeferredDiscoveryClient) client() (DiscoveryClient, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	if d.inner == nil {
+		return nil, ErrDiscoveryNotReady
+	}
+	return d.inner, nil
+}
+
+// RegisterTransports implements DiscoveryClient.
+func (d *DeferredDiscoveryClient) RegisterTransports(ctx context.Context, entries ...*SignedEntry) error {
+	c, err := d.client()
+	if err != nil {
+		return err
+	}
+	return c.RegisterTransports(ctx, entries...)
+}
+
+// RegisterTransportsV3 implements DiscoveryClient.
+func (d *DeferredDiscoveryClient) RegisterTransportsV3(ctx context.Context, version string, entries ...*Entry) error {
+	c, err := d.client()
+	if err != nil {
+		return err
+	}
+	return c.RegisterTransportsV3(ctx, version, entries...)
+}
+
+// GetTransportByID implements DiscoveryClient.
+func (d *DeferredDiscoveryClient) GetTransportByID(ctx context.Context, id uuid.UUID) (*Entry, error) {
+	c, err := d.client()
+	if err != nil {
+		return nil, err
+	}
+	return c.GetTransportByID(ctx, id)
+}
+
+// GetTransportsByEdge implements DiscoveryClient.
+func (d *DeferredDiscoveryClient) GetTransportsByEdge(ctx context.Context, pk cipher.PubKey) ([]*Entry, error) {
+	c, err := d.client()
+	if err != nil {
+		return nil, err
+	}
+	return c.GetTransportsByEdge(ctx, pk)
+}
+
+// GetAllTransports implements DiscoveryClient.
+func (d *DeferredDiscoveryClient) GetAllTransports(ctx context.Context) ([]*Entry, error) {
+	c, err := d.client()
+	if err != nil {
+		return nil, err
+	}
+	return c.GetAllTransports(ctx)
+}
+
+// GetTransportStats implements DiscoveryClient.
+func (d *DeferredDiscoveryClient) GetTransportStats(ctx context.Context, pk cipher.PubKey) (*TransportStats, error) {
+	c, err := d.client()
+	if err != nil {
+		return nil, err
+	}
+	return c.GetTransportStats(ctx, pk)
+}
+
+// GetAllTransportsStats implements DiscoveryClient.
+func (d *DeferredDiscoveryClient) GetAllTransportsStats(ctx context.Context) (*NetworkTransportStats, error) {
+	c, err := d.client()
+	if err != nil {
+		return nil, err
+	}
+	return c.GetAllTransportsStats(ctx)
+}
+
+// GetAllTransportsPerKeyStats implements DiscoveryClient.
+func (d *DeferredDiscoveryClient) GetAllTransportsPerKeyStats(ctx context.Context) (PerKeyStats, error) {
+	c, err := d.client()
+	if err != nil {
+		return nil, err
+	}
+	return c.GetAllTransportsPerKeyStats(ctx)
+}
+
+// DeleteTransport implements DiscoveryClient.
+func (d *DeferredDiscoveryClient) DeleteTransport(ctx context.Context, id uuid.UUID) error {
+	c, err := d.client()
+	if err != nil {
+		return err
+	}
+	return c.DeleteTransport(ctx, id)
+}
+
+// DeleteTransports implements DiscoveryClient.
+func (d *DeferredDiscoveryClient) DeleteTransports(ctx context.Context, ids []uuid.UUID) (int, error) {
+	c, err := d.client()
+	if err != nil {
+		return 0, err
+	}
+	return c.DeleteTransports(ctx, ids)
+}

--- a/pkg/transport/deferred_discovery_test.go
+++ b/pkg/transport/deferred_discovery_test.go
@@ -1,0 +1,81 @@
+// Package transport pkg/transport/deferred_discovery_test.go c2-net-transport
+package transport
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// stubDiscovery is a DiscoveryClient that records that it was reached.
+type stubDiscovery struct {
+	DiscoveryClient
+	calls int32
+}
+
+func (s *stubDiscovery) GetAllTransports(context.Context) ([]*Entry, error) {
+	atomic.AddInt32(&s.calls, 1)
+	return nil, nil
+}
+
+func TestDeferredDiscoveryClientFailsFastUntilConnected(t *testing.T) {
+	log := logging.MustGetLogger("deferred-disc-test")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var attempts int32
+	stub := &stubDiscovery{}
+	connect := func(context.Context) (DiscoveryClient, error) {
+		// Fail the first two attempts, then hand over the real client.
+		if atomic.AddInt32(&attempts, 1) < 3 {
+			return nil, errors.New("tpd unreachable")
+		}
+		return stub, nil
+	}
+
+	d := NewDeferredDiscoveryClient(ctx, log, time.Millisecond, connect)
+
+	// The point of the type: calls before connection fail cleanly rather
+	// than blocking the caller, which is what wedged visor boot.
+	select {
+	case <-d.Ready():
+	case <-time.After(5 * time.Second):
+		t.Fatal("deferred client never connected")
+	}
+	require.True(t, d.Connected())
+
+	_, err := d.GetAllTransports(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), atomic.LoadInt32(&stub.calls), "call should reach the real client once connected")
+}
+
+func TestDeferredDiscoveryClientBeforeConnect(t *testing.T) {
+	log := logging.MustGetLogger("deferred-disc-test")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	blocked := make(chan struct{})
+	d := NewDeferredDiscoveryClient(ctx, log, time.Hour, func(context.Context) (DiscoveryClient, error) {
+		close(blocked)
+		return nil, errors.New("tpd unreachable")
+	})
+	<-blocked
+
+	require.False(t, d.Connected())
+	// Every method must return promptly, not block and not panic.
+	_, err := d.GetAllTransports(ctx)
+	require.ErrorIs(t, err, ErrDiscoveryNotReady)
+	require.ErrorIs(t, d.RegisterTransports(ctx), ErrDiscoveryNotReady)
+	require.ErrorIs(t, d.DeleteTransport(ctx, uuid.Nil), ErrDiscoveryNotReady)
+	_, err = d.GetTransportsByEdge(ctx, cipher.PubKey{})
+	require.ErrorIs(t, err, ErrDiscoveryNotReady)
+}

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -1322,6 +1322,15 @@ func connectToTpDisc(ctx context.Context, v *Visor, log *logging.Logger) (transp
 		// returns early once ready; this cap just prevents a never-ready dmsg
 		// from blocking boot here indefinitely.
 		tpdDmsgReadyWait = 60 * time.Second
+		// tpdBootWait bounds how long boot tries to reach the transport
+		// discovery before proceeding without it. Long enough to cover a
+		// deployment that is merely slow to answer, short enough that an
+		// unreachable one costs a visor half a minute rather than its whole
+		// control plane.
+		tpdBootWait = 30 * time.Second
+		// tpdDeferredRetry is how often the background connector retries once
+		// boot has moved on.
+		tpdDeferredRetry = 10 * time.Second
 	)
 
 	conf := v.conf.Transport
@@ -1362,24 +1371,51 @@ func connectToTpDisc(ctx context.Context, v *Visor, log *logging.Logger) (transp
 		return nil, err
 	}
 
+	connect := func(context.Context) (transport.DiscoveryClient, error) {
+		return tpdclient.NewHTTP(tpdURL, v.conf.PK, v.conf.SK, httpC, pIP, v.MasterLogger())
+	}
+
+	// One bounded attempt on the boot path, so the common case (TPD reachable)
+	// is connected by the time the transport manager starts and nothing below
+	// changes.
 	tpdCRetrier := netutil.NewRetrier(log, initBO, maxBO, tries, factor)
+	bootCtx, cancelBoot := context.WithTimeout(ctx, tpdBootWait)
+	defer cancelBoot()
 
 	var tpdC transport.DiscoveryClient
 	retryFunc := func() error {
 		var err error
-		tpdC, err = tpdclient.NewHTTP(tpdURL, v.conf.PK, v.conf.SK, httpC, pIP, v.MasterLogger())
+		tpdC, err = connect(bootCtx)
 		if err != nil {
-			log.WithError(err).Error("Failed to connect to transport discovery, retrying...")
+			log.WithError(err).Debug("Transport discovery not reachable yet, retrying...")
 			return err
 		}
 		return nil
 	}
 
-	if err := tpdCRetrier.Do(context.Background(), retryFunc); err != nil {
-		return nil, err
+	if err := tpdCRetrier.Do(bootCtx, retryFunc); err == nil {
+		return tpdC, nil
 	}
 
-	return tpdC, nil
+	// Boot must NOT wait on the transport discovery. Constructing the client
+	// does network I/O (an httpauth nonce fetch), and this used to retry it
+	// unbounded on context.Background() — so a visor that could not reach the
+	// TPD never finished starting. The transport module gates the RPC server,
+	// the launcher (dmsgpty, the hypervisor RPC, every app listener) and the
+	// router, so such a visor holds dmsg sessions, answers nothing and cannot
+	// be managed remotely for as long as the TPD is away.
+	//
+	// That cascades. The deployment services are reached over dmsg, so when a
+	// visor co-located with the TPD wedges this way it takes the TPD with it,
+	// and every visor that restarts afterwards wedges on the missing TPD —
+	// observed in production spreading host by host with a rollout.
+	//
+	// Transports work before they are registered and registration is already
+	// retried on a timer, so carry on with a deferred client that connects in
+	// the background.
+	log.WithField("tpd", tpdURL).
+		Warn("Transport discovery unreachable at boot; continuing without it and connecting in the background")
+	return transport.NewDeferredDiscoveryClient(v.ctx, log, tpdDeferredRetry, connect), nil
 }
 
 // newV6ForcedHTTPClient returns an *http.Client whose underlying


### PR DESCRIPTION
`cycleLoop` closed whatever `f.done` held when it returned, racing its own stopper. The grace timer captures `f.done`, nils the field, cancels the cycle's context and then waits on its captured copy — so the loop woke on a context cancelled only *after* the field was already nil, read nil, and panicked:

```
panic: close of nil channel
  cxosub.(*Manager).cycleLoop(...) manager.go:899
  created by cxosub.(*Manager).acquireFeedLocked
```

The stopper was then left waiting on a channel nothing would ever close.

Releasing and re-acquiring a feed is the same bug from the other side: the replacement goroutine installs a new `f.done`, and the outgoing loop closes the newcomer's channel instead of its own, making the next close a "close of closed channel".

Hand the goroutine the channel it owns at launch. The race detector reports the field write at `manager.go:876` against the deferred read at `908`; with the channel passed in there is nothing shared to race on. The added test fails under `-race` without the fix and passes with it.

This was masked until now: a visor could not get far enough into boot to acquire a feed while it was still blocking on the transport discovery (#4801). With that fixed it is hit immediately — two crash loops in six minutes on a real visor, panic captured by the dev loop's crashlog. Shipping #4801 without this would trade a boot wedge for a crash loop.

`go build .`, `go test ./pkg/cxo/...` and `-race` on the new test all pass.