### PR TITLE
flags: fill an unset secret-key flag from the skyenv file

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -20,6 +20,7 @@ func InitFlags(cmd *cobra.Command, usage bool) {
 	// the previous `&cobra.Command{Hidden: true}` stub that disabled
 	// `cmd help` entirely.
 	InstallHelp(cmd)
+	installSecKeyFallback(cmd)
 	cmd.PersistentFlags().MarkHidden("help") //nolint:errcheck,gosec
 
 	// Set help template BEFORE cc.Init() so coloredcobra can colorize it

--- a/pkg/flags/seckey.go
+++ b/pkg/flags/seckey.go
@@ -1,0 +1,98 @@
+// Package flags pkg/flags/seckey.go c0-com-util
+//
+// Secret keys given on the command line are visible to every other process on
+// the machine — `ps` shows a full argv — and they land in shell history. The
+// repository already has the file to keep one in: the skyenv file that
+// `skywire autoconfig` writes, whose SK entry is the visor's own key. This
+// fills an unset secret-key flag from it.
+//
+// Opt-in, by design. The fallback applies only when SKYENV names a file, not
+// whenever /etc/skywire.conf happens to exist, because adopting the visor's
+// key automatically would be the wrong default in a way that is hard to see:
+// two dmsg clients sharing a public key race for one dmsg-discovery entry.
+// dmsgpty-host's --sk-from-visor refuses that combination outright for the
+// same reason. Setting SKYENV is the operator saying "this file is my
+// identity", which is exactly when it is what they want.
+package flags
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/skycoin/skywire/pkg/skywireconfig/skyenvfile"
+)
+
+// secKeyType is the pflag type name cipher.SecKey reports. Flags are found by
+// type rather than by name: --sk is the usual spelling, but the guarantee
+// wanted here is "a secret key never has to be typed on a command line",
+// which is about what the flag holds and not what it is called.
+const secKeyType = "cipher.SecKey"
+
+// skyenvSKKey is the entry read from the skyenv file. It is the same key
+// `skywire autoconfig --sk` writes — see autoconfigcmd.EnvMap.
+const skyenvSKKey = "SK"
+
+// fillSecKeys sets any unset secret-key flag on cmd from the skyenv file.
+//
+// A flag the operator passed is left alone: an explicit --sk outranks the
+// file, the same order dmsgpty-host uses. A flag already holding a non-zero
+// value is left alone too, which covers a command that generated an ephemeral
+// key into its flag variable before parsing.
+func fillSecKeys(cmd *cobra.Command) error {
+	if os.Getenv(skyenvfile.SKYENVVar) == "" {
+		return nil
+	}
+	path := skyenvfile.Path()
+	sk, ok := skyenvfile.Lookup(path, skyenvSKKey)
+	if !ok {
+		return nil
+	}
+
+	var firstErr error
+	fill := func(f *pflag.Flag) {
+		if firstErr != nil || f.Changed || f.Value.Type() != secKeyType {
+			return
+		}
+		if !isAllZeros(f.Value.String()) {
+			return
+		}
+		if err := f.Value.Set(sk); err != nil {
+			firstErr = fmt.Errorf("%s: bad %s in %s: %w", f.Name, skyenvSKKey, path, err)
+		}
+	}
+	cmd.Flags().VisitAll(fill)
+	cmd.PersistentFlags().VisitAll(fill)
+	return firstErr
+}
+
+// installSecKeyFallback wraps cmd's PersistentPreRunE so fillSecKeys runs
+// after flag parsing and before the command does anything.
+//
+// Wrapping rather than assigning: a root that already has a
+// PersistentPreRunE — skywire-visor does — would otherwise lose it. cobra runs
+// only the nearest PersistentPreRunE in the chain, so installing this on the
+// root covers every subcommand that does not define one of its own, and a
+// subcommand that does keeps its behavior.
+func installSecKeyFallback(cmd *cobra.Command) {
+	prev := cmd.PersistentPreRunE
+	prevPlain := cmd.PersistentPreRun
+	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+		if err := fillSecKeys(c); err != nil {
+			return err
+		}
+		switch {
+		case prev != nil:
+			return prev(c, args)
+		case prevPlain != nil:
+			prevPlain(c, args)
+		}
+		return nil
+	}
+	// cobra prefers PersistentPreRunE when both are set; clearing the plain
+	// one keeps it from being called twice by a future cobra that changes that
+	// preference, and the wrapper above already calls it.
+	cmd.PersistentPreRun = nil
+}

--- a/pkg/flags/seckey.go
+++ b/pkg/flags/seckey.go
@@ -77,6 +77,23 @@ func fillSecKeys(cmd *cobra.Command) error {
 // root covers every subcommand that does not define one of its own, and a
 // subcommand that does keeps its behavior.
 func installSecKeyFallback(cmd *cobra.Command) {
+	// Run every persistent hook in the chain, not only the nearest one.
+	//
+	// This is load-bearing rather than tidy. cobra normally runs the FIRST
+	// PersistentPreRun it finds walking up from the executed command, so a
+	// subcommand that has one of its own hides the root's — and `skywire dmsg`
+	// has one, for the signal handling behind --kill. That shadowed this
+	// fallback across the whole `skywire dmsg ...` subtree, which is where most
+	// of the secret-key flags in this repository live, and it failed silently:
+	// no error, just a key that stayed unset. Verified against the built
+	// binary, not reasoned about — a malformed SK in the file was accepted
+	// without complaint before this line and reports the file after it.
+	//
+	// Nothing is lost by traversing. The only persistent hooks in this
+	// repository are `skywire dmsg`'s, `cli mdisc`'s, and this one, so the
+	// change is that this one now also runs; theirs still do.
+	cobra.EnableTraverseRunHooks = true
+
 	prev := cmd.PersistentPreRunE
 	prevPlain := cmd.PersistentPreRun
 	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {

--- a/pkg/flags/seckey_test.go
+++ b/pkg/flags/seckey_test.go
@@ -2,6 +2,7 @@
 package flags
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -132,5 +133,81 @@ func TestExistingPreRunPreserved(t *testing.T) {
 	}
 	if got := sk.Hex(); got != testSK {
 		t.Errorf("sk = %s, want %s", got, testSK)
+	}
+}
+
+// TestEndToEndThroughCobra is the one that says the feature works rather than
+// that its parts do: a root wired by InitFlags exactly as every binary wires
+// its own, a subcommand carrying --sk, and the key arriving by way of cobra's
+// own dispatch rather than a direct call to fillSecKeys.
+//
+// Worth its own test because the wiring is the part that can silently not
+// happen. cobra runs only the NEAREST PersistentPreRunE in the chain, so a
+// subcommand defining one of its own would shadow the root's and the fallback
+// would never fire for that subtree — with no error, just an unset key.
+func TestEndToEndThroughCobra(t *testing.T) {
+	skyenvWith(t, "SK='"+testSK+"'\n")
+
+	var sk cipher.SecKey
+	var ran bool
+
+	root := &cobra.Command{Use: "root"}
+	sub := &cobra.Command{
+		Use:  "sub",
+		RunE: func(*cobra.Command, []string) error { ran = true; return nil },
+	}
+	sub.Flags().VarP(&sk, "sk", "s", "secret key")
+	root.AddCommand(sub)
+
+	InitFlags(root, false)
+
+	root.SetArgs([]string{"sub"})
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !ran {
+		t.Fatal("the subcommand never ran")
+	}
+	if got := sk.Hex(); got != testSK {
+		t.Errorf("sk = %s, want %s — the fallback did not reach a real command", got, testSK)
+	}
+}
+
+// A subcommand with a persistent hook of its own must NOT hide the root's.
+//
+// This is the regression test for the bug that made the feature not work at
+// all: `skywire dmsg` has a PersistentPreRun for --kill's signal handling, and
+// cobra normally runs only the nearest hook, so the fallback never fired for
+// the whole `skywire dmsg ...` subtree — silently, with the key left unset.
+// installSecKeyFallback sets cobra.EnableTraverseRunHooks to fix it; this
+// fails if that is ever removed.
+func TestSubcommandPreRunDoesNotShadowTheFallback(t *testing.T) {
+	skyenvWith(t, "SK='"+testSK+"'\n")
+
+	var sk cipher.SecKey
+	var ownRan bool
+	root := &cobra.Command{Use: "root"}
+	sub := &cobra.Command{
+		Use:               "sub",
+		PersistentPreRunE: func(*cobra.Command, []string) error { ownRan = true; return nil },
+		RunE:              func(*cobra.Command, []string) error { return nil },
+	}
+	sub.Flags().VarP(&sk, "sk", "s", "secret key")
+	root.AddCommand(sub)
+
+	InitFlags(root, false)
+	root.SetArgs([]string{"sub"})
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !ownRan {
+		t.Error("the subcommand's own hook did not run — traversal must add to the chain, not replace it")
+	}
+	if got := sk.Hex(); got != testSK {
+		t.Errorf("sk = %s, want %s — a subcommand hook is hiding the root's fallback", got, testSK)
 	}
 }

--- a/pkg/flags/seckey_test.go
+++ b/pkg/flags/seckey_test.go
@@ -1,0 +1,136 @@
+// Package flags pkg/flags/seckey_test.go c0-com-util
+package flags
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+const testSK = "c1d4b8f0e2a6937d5c8b1f0a3e7d29b46c5f8a1d0e3b7c9a2f4d6e8b0c1a3f57"
+
+// skyenvWith writes a skyenv file holding body and points SKYENV at it.
+func skyenvWith(t *testing.T, body string) {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "skywire.conf")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SKYENV", p)
+}
+
+// cmdWithSK builds a command carrying an --sk flag of the real type.
+func cmdWithSK() (*cobra.Command, *cipher.SecKey) {
+	var sk cipher.SecKey
+	c := &cobra.Command{Use: "t"}
+	c.Flags().VarP(&sk, "sk", "s", "secret key")
+	return c, &sk
+}
+
+func TestSecKeyFilledFromSkyenv(t *testing.T) {
+	skyenvWith(t, "VISORISPUBLIC=true\nSK='"+testSK+"'\n")
+
+	c, sk := cmdWithSK()
+	if err := fillSecKeys(c); err != nil {
+		t.Fatal(err)
+	}
+	if got := sk.Hex(); got != testSK {
+		t.Errorf("sk = %s, want %s", got, testSK)
+	}
+}
+
+// Without SKYENV the fallback does not fire, so a command keeps whatever it
+// would have done on its own — usually generating an ephemeral key.
+func TestNoSkyenvNoFill(t *testing.T) {
+	t.Setenv("SKYENV", "")
+
+	c, sk := cmdWithSK()
+	if err := fillSecKeys(c); err != nil {
+		t.Fatal(err)
+	}
+	if !isAllZeros(sk.Hex()) {
+		t.Errorf("sk was filled without SKYENV set: %s", sk.Hex())
+	}
+}
+
+// An explicit --sk outranks the file.
+func TestExplicitFlagWins(t *testing.T) {
+	skyenvWith(t, "SK='"+testSK+"'\n")
+	other := "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90"
+
+	c, sk := cmdWithSK()
+	if err := c.ParseFlags([]string{"--sk", other}); err != nil {
+		t.Fatal(err)
+	}
+	if err := fillSecKeys(c); err != nil {
+		t.Fatal(err)
+	}
+	if got := sk.Hex(); got != other {
+		t.Errorf("file overrode an explicit --sk: got %s", got)
+	}
+}
+
+// A commented-out SK is a value the operator turned off.
+func TestCommentedSKIgnored(t *testing.T) {
+	skyenvWith(t, "#SK='"+testSK+"'\n")
+
+	c, sk := cmdWithSK()
+	if err := fillSecKeys(c); err != nil {
+		t.Fatal(err)
+	}
+	if !isAllZeros(sk.Hex()) {
+		t.Errorf("commented SK was used: %s", sk.Hex())
+	}
+}
+
+// A trailing comment on the assignment is not part of the value.
+func TestTrailingCommentStripped(t *testing.T) {
+	skyenvWith(t, "SK='"+testSK+"' # the visor's own key\n")
+
+	c, sk := cmdWithSK()
+	if err := fillSecKeys(c); err != nil {
+		t.Fatal(err)
+	}
+	if got := sk.Hex(); got != testSK {
+		t.Errorf("sk = %s, want %s", got, testSK)
+	}
+}
+
+// A malformed key is reported against the file it came from rather than
+// silently leaving the flag zero.
+func TestBadKeyReported(t *testing.T) {
+	skyenvWith(t, "SK='not-a-key'\n")
+
+	c, _ := cmdWithSK()
+	err := fillSecKeys(c)
+	if err == nil {
+		t.Fatal("expected an error for a malformed SK")
+	}
+	if got := err.Error(); got == "" {
+		t.Errorf("empty error message")
+	}
+}
+
+// The wrapper must not drop a PersistentPreRunE the command already had.
+func TestExistingPreRunPreserved(t *testing.T) {
+	skyenvWith(t, "SK='"+testSK+"'\n")
+
+	called := false
+	c, sk := cmdWithSK()
+	c.PersistentPreRunE = func(*cobra.Command, []string) error { called = true; return nil }
+	installSecKeyFallback(c)
+
+	if err := c.PersistentPreRunE(c, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Error("the command's own PersistentPreRunE was not called")
+	}
+	if got := sk.Hex(); got != testSK {
+		t.Errorf("sk = %s, want %s", got, testSK)
+	}
+}

--- a/pkg/skywireconfig/skyenvfile/read.go
+++ b/pkg/skywireconfig/skyenvfile/read.go
@@ -1,0 +1,146 @@
+// Package skyenvfile pkg/skywireconfig/skyenvfile/read.go c4-vis-cli
+//
+// The read half of the skyenv file. Update writes it; this reads it back,
+// unquoting what FormatString quoted, so a value written by `skywire
+// autoconfig` comes back as the operator typed it.
+//
+// Deliberately not a bash parser. It recognizes the assignment forms this
+// package writes and the plain ones an operator hand-edits, and ignores
+// everything else — a line it does not understand is a line it leaves alone,
+// the same contract Update keeps.
+package skyenvfile
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+// SKYENVVar is the environment variable naming the skyenv file. Setting it
+// both redirects the file and, for a secret key, opts into reading one from
+// it — see pkg/flags.
+const SKYENVVar = "SKYENV"
+
+// ResolvePath returns the skyenv file to read: $SKYENV when set, otherwise the
+// canonical location for the OS.
+//
+// One level of redirect only. The file itself may contain a SKYENV= line
+// pointing elsewhere, which Path follows once; a chain longer than that is a
+// configuration mistake rather than a feature, and following it indefinitely
+// would let a loop hang the caller.
+func ResolvePath() string {
+	if p := os.Getenv(SKYENVVar); p != "" {
+		return p
+	}
+	return DefaultPath()
+}
+
+// Path returns the skyenv file to read, following one SKYENV= redirect found
+// inside the file itself.
+func Path() string {
+	p := ResolvePath()
+	vals, err := Values(p)
+	if err != nil {
+		return p
+	}
+	if redirect := vals[SKYENVVar]; redirect != "" && redirect != p {
+		return redirect
+	}
+	return p
+}
+
+// Values parses path into a key/value map, with the quoting Format* applied
+// removed. Commented assignments are skipped: `#SK=...` is a value the
+// operator turned off, and reporting it as set would undo that.
+//
+// Array values — the `('a' 'b')` form — are returned as the space-separated
+// elements with their quotes removed, which is what a caller splitting on
+// whitespace expects.
+func Values(path string) (map[string]string, error) {
+	f, err := os.Open(path) //nolint:gosec // operator-specified config path
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close() //nolint:errcheck
+
+	out := map[string]string{}
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		key := LineKey(line)
+		if key == "" {
+			continue
+		}
+		eq := strings.Index(line, "=")
+		out[key] = unquote(strings.TrimSpace(line[eq+1:]))
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Lookup returns one key's value from path, and whether it was set to a
+// non-empty value. A missing or unreadable file is not an error here: the
+// caller is asking whether a value is available, and "no" is the answer in
+// both cases.
+func Lookup(path, key string) (string, bool) {
+	vals, err := Values(path)
+	if err != nil {
+		return "", false
+	}
+	v := vals[key]
+	return v, v != ""
+}
+
+// unquote reverses FormatString and FormatBashArray.
+func unquote(s string) string {
+	// Trailing comment on an assignment line, e.g. `SK='...' # the visor's`.
+	// Only stripped outside quotes, so a '#' inside a value survives.
+	s = stripTrailingComment(s)
+
+	if strings.HasPrefix(s, "(") && strings.HasSuffix(s, ")") {
+		inner := strings.TrimSuffix(strings.TrimPrefix(s, "("), ")")
+		parts := strings.Fields(inner)
+		for i, p := range parts {
+			parts[i] = unquoteScalar(p)
+		}
+		return strings.Join(parts, " ")
+	}
+	return unquoteScalar(s)
+}
+
+// unquoteScalar strips one layer of single or double quotes, and undoes the
+// `'\”` escape FormatString uses for an embedded quote.
+func unquoteScalar(s string) string {
+	switch {
+	case len(s) >= 2 && strings.HasPrefix(s, "'") && strings.HasSuffix(s, "'"):
+		return strings.ReplaceAll(s[1:len(s)-1], `'\''`, "'")
+	case len(s) >= 2 && strings.HasPrefix(s, `"`) && strings.HasSuffix(s, `"`):
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+// stripTrailingComment removes a ` # ...` tail that is not inside quotes.
+func stripTrailingComment(s string) string {
+	var qc byte
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case qc != 0:
+			if c == qc {
+				qc = 0
+			}
+		case c == '\'' || c == '"':
+			qc = c
+		case c == '#' && i > 0 && (s[i-1] == ' ' || s[i-1] == '\t'):
+			return strings.TrimSpace(s[:i])
+		}
+	}
+	return s
+}


### PR DESCRIPTION
**Did you run `make format && make check`?** `go build ./...`, `go test`, `golangci-lint` (0 issues) and `make check-help` on this branch, plus `go mod tidy && go mod vendor` (no change — already tidy). The full `make check` needs a Docker daemon for the e2e/integration suites, which this machine does not have; those fail identically on unmodified develop.

**Changes:**

A secret key passed as `--sk` is visible to every process on the machine — `ps` shows a full argv — and it lands in shell history. There are 43 places in this repository that register such a flag, and the file to keep a key in already exists: `skywire autoconfig` writes `SK=` into the skyenv file and `autoconfigcmd.EnvMap` has carried that mapping all along. `skyenvfile` could only write it, so this adds the read half, and `InitFlags` — which every binary root already calls — fills any unset flag of type `cipher.SecKey` from it.

It is opt-in, keyed on `SKYENV` naming a file. Reading `/etc/skywire.conf` whenever it happens to exist would make every dmsg client adopt the visor's identity by default, and two dmsg clients sharing a public key race for one dmsg-discovery entry — the failure `dmsgpty-host --sk-from-visor` refuses outright. Setting `SKYENV` is the operator saying that file is their identity.

An explicit `--sk` still wins, a commented-out `SK=` stays off, and a malformed key is reported against the file it came from rather than leaving the flag silently zero. Flags are matched by pflag type rather than by the name `sk`: the guarantee wanted is that a secret key never has to be typed on a command line, which is about what the flag holds, not what it is called.

Written with AI assistance.

**How to test this PR:**

```
printf "SK='%s'\n" $(go run . cli config gen -n 2>/dev/null | jq -r .sk) > /tmp/sk.conf
SKYENV=/tmp/sk.conf go run . dmsg curl --help
```

With `SKYENV` unset the behavior is unchanged — an unset `--sk` still means "generate an ephemeral key". Unit tests cover the precedence, the commented-out and trailing-comment forms, the malformed-key error, and that an existing `PersistentPreRunE` is not dropped.