### PR TITLE
feat(dmsg): let a standalone client attach to a local visor's relay

### DIFF
--- a/cmd/skywire-cli/commands/dmsg/attach.go
+++ b/cmd/skywire-cli/commands/dmsg/attach.go
@@ -1,0 +1,165 @@
+// Package clidmsg cmd/skywire-cli/commands/dmsg/attach.go c4-vis-cli
+// `skywire cli dmsg attach` — inspect and exercise a local visor's dmsg relay
+// acceptor (pkg/visor/init_dmsg_relay_local.go).
+//
+// Attaching is how a standalone dmsg process stops holding dmsg server sessions
+// WITHOUT changing its key: it gets one session, to the visor beside it, over a
+// unix socket, and its streams are forwarded over that visor's sessions and
+// transports. This command is the two checks an operator needs before trusting
+// that path:
+//
+//	skywire cli dmsg attach                 # what is on the other end of the socket?
+//	skywire cli dmsg attach --sk <key>      # would MY key be admitted?
+//
+// The first needs no identity at all — it reads the acceptor's hello and hangs
+// up — which is deliberate: verifying a socket must not mint a key, and a
+// deployment that has paid for hundreds of throwaway identities does not need
+// another source of them.
+//
+// The end-to-end path with real traffic is the --attach flag on the standalone
+// tools: `skywire cli dmsg curl --attach <socket> dmsg://<pk>:80/...` fetches
+// over the visor's sessions under the caller's own key.
+package clidmsg
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgclient"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+var (
+	// attachSocket is the shared --attach value: a unix socket path, or
+	// "tcp://host:port" for a visor serving the loopback listener. Read by
+	// startDmsgClient (curl.go) so every standalone subcommand that bootstraps
+	// its own client can run attached instead.
+	attachSocket string
+	attachDial   string
+)
+
+func init() {
+	attachCmd.Flags().SortFlags = false
+	attachCmd.Flags().VarP(&sk, "sk", "s",
+		"secret key to attach with — omit to only probe the acceptor's identity")
+	attachCmd.Flags().StringVar(&attachDial, "dial", "",
+		"after attaching, dial `<pk>:<port>` over the relay to prove the path end to end")
+	attachCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "fatal",
+		"[ debug | warn | error | fatal | panic | trace | info ]")
+	RootCmd.AddCommand(attachCmd)
+}
+
+// defaultAttachSocket is where a visor with `dmsg.local_relay.socket` unset
+// binds its acceptor. Kept in step with pkg/visor's
+// defaultLocalRelaySocketName; a wrong guess here costs one clear "no such
+// file" and not a misdial, so it is not worth an RPC round-trip to the visor.
+func defaultAttachSocket() string {
+	return filepath.Join(skyenv.LocalPath, "dmsg_relay.sock")
+}
+
+var attachCmd = &cobra.Command{
+	Use:   "attach [socket]",
+	Short: "Inspect a local visor's dmsg relay acceptor",
+	Long: `Inspect a local visor's dmsg relay acceptor.
+
+A process attached to the acceptor holds ONE dmsg session — to the visor, over
+this socket — instead of sessions to dmsg servers, publishes no discovery
+entry, and keeps its own key. Its streams ride the visor's sessions and
+transports.
+
+With no --sk this only reads the acceptor's identity and hangs up. With --sk it
+completes the attach, which is what proves the key is admitted: the visor's
+allowed_keys check runs after the session handshake has proven the key.
+
+The socket defaults to <local_path>/dmsg_relay.sock. Prefix a "tcp://" address
+instead to reach a visor serving the loopback listener.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		target := defaultAttachSocket()
+		if len(args) == 1 {
+			target = args[0]
+		}
+		network, addr := dmsgclient.AttachTarget(target)
+		log := logging.MustGetLogger("dmsg:attach")
+		if lvl, err := logging.LevelFromString(logLvl); err == nil {
+			logging.SetLevel(lvl)
+		}
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+		defer cancel()
+
+		if sk.Null() {
+			relayPK, port, err := dmsgclient.LocalRelayIdentity(ctx, network, addr)
+			if err != nil {
+				return err
+			}
+			cmd.Printf("acceptor: %s://%s\nvisor:    %s\nport:     %d\n", network, addr, relayPK, port)
+			cmd.Println("pass --sk to complete an attach and confirm the key is admitted")
+			return nil
+		}
+
+		pk, err := sk.PubKey()
+		if err != nil {
+			return fmt.Errorf("invalid secret key: %w", err)
+		}
+		dmsgC, stop, relayPK, err := dmsgclient.StartDmsgLocalRelay(ctx, log, pk, sk, network, addr)
+		if err != nil {
+			return err
+		}
+		defer stop()
+
+		cmd.Printf("attached: %s\nvisor:    %s\n", pk, relayPK)
+		for _, ses := range dmsgC.AllSessions() {
+			cmd.Printf("session:  %s (%s)\n", ses.RemotePK(), ses.Protocol())
+		}
+		if attachDial == "" {
+			return nil
+		}
+		dst, err := parseAttachDial(attachDial)
+		if err != nil {
+			return err
+		}
+		stream, err := dmsgC.DialStream(ctx, dst)
+		if err != nil {
+			return fmt.Errorf("dial %s over the relay: %w", dst, err)
+		}
+		defer stream.Close() //nolint:errcheck
+		cmd.Printf("dialed:   %s over the relay\n", dst)
+		return nil
+	},
+}
+
+// parseAttachDial parses the --dial "<pk>:<port>" destination.
+func parseAttachDial(s string) (dmsg.Addr, error) {
+	var addr dmsg.Addr
+	host, portStr, err := splitLastColon(s)
+	if err != nil {
+		return addr, err
+	}
+	var pk cipher.PubKey
+	if err := pk.Set(host); err != nil {
+		return addr, fmt.Errorf("--dial %q: %w", s, err)
+	}
+	var port uint16
+	if _, err := fmt.Sscanf(portStr, "%d", &port); err != nil || port == 0 {
+		return addr, fmt.Errorf("--dial %q: bad port", s)
+	}
+	return dmsg.Addr{PK: pk, Port: port}, nil
+}
+
+// splitLastColon splits "<pk>:<port>" on its final colon.
+func splitLastColon(s string) (string, string, error) {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == ':' {
+			return s[:i], s[i+1:], nil
+		}
+	}
+	return "", "", fmt.Errorf("%q is not <pk>:<port>", s)
+}

--- a/cmd/skywire-cli/commands/dmsg/curl.go
+++ b/cmd/skywire-cli/commands/dmsg/curl.go
@@ -23,6 +23,7 @@ import (
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgclient"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/visor"
@@ -56,6 +57,7 @@ func init() {
 	curlCmd.Flags().StringVar(&curlVerboseLevel, "verbose-level", "debug", "minimum log level when --verbose is set: trace|debug|info|warn|error")
 	curlCmd.Flags().BoolVar(&curlWT, "wt", false, "standalone (--sk): dial the dmsg-server session over WebTransport (HTTP/3) with no TCP/QUIC fallback")
 	curlCmd.Flags().StringVar(&curlDisc, "disc", "", "standalone (--wt): HTTP dmsg-discovery URL to fetch the WebTransport server set from (e.g. http://dmsg-discovery:9090)")
+	curlCmd.Flags().StringVar(&attachSocket, "attach", "", "standalone (--sk): attach to a local visor's dmsg relay `socket` instead of dialing dmsg servers")
 	if os.Getenv("DMSG_SK") != "" {
 		sk.Set(os.Getenv("DMSG_SK")) //nolint
 	}
@@ -365,6 +367,18 @@ func curlStandalone(ctx context.Context, log *logging.Logger, pk cipher.PubKey, 
 
 // startDmsgClient starts a standalone dmsg client
 func startDmsgClient(ctx context.Context, log *logging.Logger, pk cipher.PubKey, sk cipher.SecKey) (*dmsg.Client, func(), error) {
+	// --attach: ride the local visor's relay instead of dialing servers. It
+	// comes first because it is mutually exclusive with everything below —
+	// an attached client has no server session and no discovery entry, and
+	// seeding it with the embedded prod server set would only give the serve
+	// loop somewhere else to go if the socket were briefly unavailable, which
+	// is precisely the fallback an operator chooses --attach to prevent.
+	if attachSocket != "" {
+		network, addr := dmsgclient.AttachTarget(attachSocket)
+		c, stop, _, err := dmsgclient.StartDmsgLocalRelay(ctx, log, pk, sk, network, addr)
+		return c, stop, err
+	}
+
 	// Use DMSG servers from deployment config (respects SKYDEPLOY env override).
 	if len(dmsg.Prod.DmsgServers) == 0 {
 		return nil, nil, fmt.Errorf("no DMSG servers configured")

--- a/cmd/skywire-cli/commands/dmsg/root.go
+++ b/cmd/skywire-cli/commands/dmsg/root.go
@@ -30,7 +30,9 @@ These commands fall into three families:
     diag          runtime diagnostics (porter / reconnect)
 
   standalone dmsg tools (bootstrap their own dmsg client; work with
-  no local visor — pass --sk for a stable identity)
+  no local visor — pass --sk for a stable identity, or --attach to
+  ride a local visor's sessions while keeping that identity)
+    attach        inspect the local visor's dmsg relay acceptor
     curl          fetch data over dmsg (HTTP-over-dmsg)
     cat           splice stdio with a peer over dmsg or skynet
     scp           copy a file to/from a remote visor's dmsgscp host

--- a/pkg/dmsg/dmsg/relay_local.go
+++ b/pkg/dmsg/dmsg/relay_local.go
@@ -1,0 +1,282 @@
+// Package dmsg pkg/dmsg/dmsg/relay_local.go
+//
+// The LOCAL half of the relay (see client_relay.go). AcceptRelaySession takes a
+// plain net.Conn and keeps the attached peer's own identity, so the pipe under
+// it is free: today the visor feeds it from skynet (a skywire route to
+// skyenv.DmsgRelayPort), and here it is fed from a unix socket or a loopback
+// listener on the same host.
+//
+// What that buys is a STANDALONE process — its own keypair, its own binary, no
+// router, no visor — holding a dmsg identity without holding dmsg server
+// sessions. The dmsgweb proxy is the motivating case: it runs under a key the
+// survey whitelist knows, so the key must NOT rotate, and every restart of it
+// costs the deployment a fresh set of server sessions plus a discovery entry
+// churn. Attached locally it keeps the key, holds exactly one session (to the
+// visor beside it), publishes no entry, and its streams are forwarded over the
+// VISOR's sessions and transports — which is what the visor is already paying
+// for.
+//
+// The wire under the socket is identical to the skynet one: a hello preamble so
+// the attaching process can learn which key to run the Noise XK handshake
+// against, then the same Noise+yamux dmsg session. Nothing above the pipe knows
+// the difference, which is the point — the carrier stays CarrierSkynet and the
+// session behaves as any other relay attachment (DialStream's phase 0,
+// RelayOnly's "exactly one session", the relay-slot accounting).
+//
+// AUTHORIZATION. Attaching here is a real grant: the attached process dials
+// dmsg under ITS OWN key but over the visor's sessions, and is charged to the
+// visor's relay slots. Two independent gates, and the acceptor is opt-in:
+//
+//   - The listener itself. A unix socket's file permissions are the gate — mode
+//     0600 means "a process running as the visor's user", which is already a
+//     process that could read the visor's own secret key off disk, so the grant
+//     adds nothing it did not have. This is why the unix socket is the default
+//     and why it is created 0600.
+//   - The allow callback, same shape as the skynet acceptor's. The Noise XK
+//     handshake PROVES the attacher holds the secret key for the PK it claims,
+//     so an allow that checks a configured key list is cryptographic
+//     authentication and not a hint. A listener with no filesystem gate
+//     (loopback TCP) must therefore be paired with a non-empty key list; the
+//     visor refuses to bind one otherwise.
+//
+// There is deliberately no third option: no network-facing acceptor, no
+// "anyone on localhost" TCP default.
+package dmsg
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// The local-attach hello: the ONLY bytes on the socket that are not the dmsg
+// session itself. It exists because the attaching side must know the acceptor's
+// public key BEFORE it can speak dmsg at all — the session handshake is Noise
+// XK, whose initiator needs the responder's static key up front. Without the
+// preamble every attaching tool would have to learn the visor's PK out of band
+// (parse skywire-config.json, or hold RPC credentials just to ask), and would
+// get an opaque handshake failure when that guess went stale. With it the
+// socket path is the whole configuration.
+//
+// It is a local-only framing. The skynet acceptor sends nothing of the kind:
+// there the PK is what the route was set up for, so it is already known.
+const (
+	localRelayMagic       = "DRLY"
+	localRelayHelloV1     = 1
+	localRelayHelloLen    = len(localRelayMagic) + 1 + len(cipher.PubKey{}) + 2
+	localRelayHelloIOTime = 10 * time.Second
+)
+
+// ErrLocalRelayHello is returned when the bytes at the head of a local relay
+// conn are not a hello this build understands — most often because the socket
+// path points at something that is not a dmsg relay acceptor at all.
+var ErrLocalRelayHello = errors.New("dmsg: not a local dmsg relay acceptor")
+
+// writeLocalRelayHello writes the acceptor's identity preamble: magic, version,
+// the acceptor's public key, and the dmsg port its relay is published on (so
+// the attaching side can synthesize the same skynet://<pk>:<port> address the
+// route-carried attach would have used, and logs/`visor state` read alike).
+func writeLocalRelayHello(w io.Writer, pk cipher.PubKey, port uint16) error {
+	b := make([]byte, 0, localRelayHelloLen)
+	b = append(b, localRelayMagic...)
+	b = append(b, localRelayHelloV1)
+	b = append(b, pk[:]...)
+	b = binary.BigEndian.AppendUint16(b, port)
+	_, err := w.Write(b)
+	return err
+}
+
+// readLocalRelayHello reads the preamble written by writeLocalRelayHello.
+func readLocalRelayHello(r io.Reader) (cipher.PubKey, uint16, error) {
+	var pk cipher.PubKey
+	b := make([]byte, localRelayHelloLen)
+	if _, err := io.ReadFull(r, b); err != nil {
+		if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
+			return pk, 0, fmt.Errorf("%w: short hello", ErrLocalRelayHello)
+		}
+		return pk, 0, err
+	}
+	if string(b[:len(localRelayMagic)]) != localRelayMagic {
+		return pk, 0, fmt.Errorf("%w: bad magic", ErrLocalRelayHello)
+	}
+	if v := b[len(localRelayMagic)]; v != localRelayHelloV1 {
+		return pk, 0, fmt.Errorf("%w: unsupported hello version %d", ErrLocalRelayHello, v)
+	}
+	off := len(localRelayMagic) + 1
+	copy(pk[:], b[off:off+len(pk)])
+	if pk.Null() {
+		return pk, 0, fmt.Errorf("%w: null public key", ErrLocalRelayHello)
+	}
+	port := binary.BigEndian.Uint16(b[off+len(pk):])
+	return pk, port, nil
+}
+
+// ServeLocalRelay accepts local attach conns on lis and serves each as a relay
+// session on this client, exactly as the skynet acceptor does — the pipe is the
+// only difference. It blocks until lis fails or ctx is done, so callers run it
+// in their own goroutine; lis is closed on return.
+//
+// port is what the hello advertises: the dmsg port this visor's relay is
+// published on (skyenv.DmsgRelayPort), so an attached peer nominates the same
+// address whichever pipe it came in over.
+//
+// allow is the SAME callback shape the skynet acceptor passes to
+// AcceptRelaySession, and carries the same meaning: it is consulted after the
+// Noise handshake has proven the peer's key, and refusing closes the conn. A nil
+// allow admits any key that can open lis — correct ONLY when the listener
+// itself is the gate (a 0600 unix socket). See this file's package comment.
+func (ce *Client) ServeLocalRelay(ctx context.Context, lis net.Listener, port uint16, allow func(cipher.PubKey) bool) error {
+	defer lis.Close() //nolint:errcheck
+
+	// Unblock the Accept below on cancellation: a unix listener has no other
+	// way out, and leaving the goroutine parked would hold the socket file
+	// past the visor's shutdown and make the NEXT start fail to bind it.
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = lis.Close() //nolint:errcheck
+		case <-ce.done:
+			_ = lis.Close() //nolint:errcheck
+		}
+	}()
+
+	for {
+		conn, err := lis.Accept()
+		if err != nil {
+			if ctx.Err() != nil || isClosed(ce.done) || errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return err
+		}
+		go func(conn net.Conn) {
+			// The hello is bounded: a local process that connects and then
+			// never reads would otherwise pin this goroutine (and a relay
+			// slot's worth of attention) forever.
+			_ = conn.SetWriteDeadline(time.Now().Add(localRelayHelloIOTime)) //nolint:errcheck
+			if err := writeLocalRelayHello(conn, ce.pk, port); err != nil {
+				ce.log.WithError(err).Debug("dmsg local relay: hello write failed")
+				_ = conn.Close() //nolint:errcheck
+				return
+			}
+			// Clear it again: the session that follows manages its own
+			// deadlines, and a stale write deadline would kill it mid-stream.
+			_ = conn.SetWriteDeadline(time.Time{}) //nolint:errcheck
+			if err := ce.AcceptRelaySession(ctx, conn, allow); err != nil {
+				ce.log.WithError(err).Debug("dmsg local relay session ended with error")
+			}
+		}(conn)
+	}
+}
+
+// LocalRelayDialer dials the local relay acceptor at network/addr ("unix" +
+// socket path, or "tcp" + a loopback address). It is the raw dial, hello and
+// all: see DialLocalRelay and AttachLocalRelay for the two things callers
+// actually do with it.
+type LocalRelayDialer struct {
+	Network string
+	Addr    string
+}
+
+// DialLocalRelay opens one conn to the acceptor and reads its hello, returning
+// the conn positioned at the first byte of the dmsg session along with the
+// acceptor's key and relay port.
+func (d LocalRelayDialer) DialLocalRelay(ctx context.Context, expect *cipher.PubKey) (net.Conn, cipher.PubKey, uint16, error) {
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(ctx, d.Network, d.Addr)
+	if err != nil {
+		return nil, cipher.PubKey{}, 0, err
+	}
+	deadline := time.Now().Add(localRelayHelloIOTime)
+	if dl, ok := ctx.Deadline(); ok && dl.Before(deadline) {
+		deadline = dl
+	}
+	_ = conn.SetReadDeadline(deadline) //nolint:errcheck
+	pk, port, err := readLocalRelayHello(conn)
+	if err != nil {
+		_ = conn.Close() //nolint:errcheck
+		return nil, cipher.PubKey{}, 0, fmt.Errorf("dmsg: local relay %s://%s: %w", d.Network, d.Addr, err)
+	}
+	_ = conn.SetReadDeadline(time.Time{}) //nolint:errcheck
+	// A mismatch here means the socket now fronts a DIFFERENT visor than the
+	// one this client nominated — a reinstall, or a socket path reused by
+	// another instance. Failing loudly beats handing the conn to a Noise XK
+	// handshake keyed to the old PK, which fails with nothing to read from.
+	if expect != nil && pk != *expect {
+		_ = conn.Close() //nolint:errcheck
+		return nil, cipher.PubKey{}, 0, fmt.Errorf("dmsg: local relay %s://%s is %s, expected %s", d.Network, d.Addr, pk, *expect)
+	}
+	return conn, pk, port, nil
+}
+
+// PubKey probes the acceptor for its public key and relay port, then hangs up.
+// A caller needs both before it can nominate the relay (SetRelayPeers takes a
+// key, and the Noise XK session handshake needs it too).
+func (d LocalRelayDialer) PubKey(ctx context.Context) (cipher.PubKey, uint16, error) {
+	conn, pk, port, err := d.DialLocalRelay(ctx, nil)
+	if err != nil {
+		return cipher.PubKey{}, 0, err
+	}
+	_ = conn.Close() //nolint:errcheck
+	return pk, port, nil
+}
+
+// SessionDialer returns a Config.SessionDialer that serves the skynet carrier
+// from this local socket instead of from a skywire route. The address it is
+// handed is the usual "skynet://<pk>:<port>", and the PK in it is checked
+// against the acceptor's hello — so a client that nominated visor A cannot be
+// silently attached to visor B by a swapped socket.
+//
+// It is the whole client-side counterpart: a standalone process installs this
+// (SetSessionDialer), nominates the visor (SetRelayPeers), and the ordinary
+// serve loop does the rest.
+func (d LocalRelayDialer) SessionDialer() SessionDialer {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if network != CarrierSkynet {
+			return nil, fmt.Errorf("dmsg local relay dialer: unsupported carrier %q", network)
+		}
+		pk, _, err := ParseSkynetAddr(addr)
+		if err != nil {
+			return nil, err
+		}
+		conn, _, _, err := d.DialLocalRelay(ctx, &pk)
+		return conn, err
+	}
+}
+
+// AttachLocalRelay points this client at the local relay acceptor at
+// network/addr: it probes the acceptor for its identity, installs the session
+// dialer that serves the skynet carrier from that socket, and nominates the
+// acceptor as this client's relay. It returns the acceptor's public key.
+//
+// It does NOT change this client's identity, and deliberately cannot: the key
+// is fixed at NewClient, the acceptor learns it from the session handshake, and
+// every stream this client dials afterwards is signed with it and arrives at
+// the destination under it. That is the whole reason to attach rather than to
+// run a second client — a key the deployment already knows (a whitelisted
+// survey key, a service PK in someone's config) keeps working.
+//
+// Pair it with Config.RelayOnly to get the intended end state: one session, to
+// the visor, and no discovery entry at all. Without RelayOnly the client also
+// keeps MinSessions server sessions and publishes an entry naming them, which
+// is a legitimate but different thing to want.
+func (ce *Client) AttachLocalRelay(ctx context.Context, network, addr string) (cipher.PubKey, error) {
+	d := LocalRelayDialer{Network: network, Addr: addr}
+	pk, port, err := d.PubKey(ctx)
+	if err != nil {
+		return cipher.PubKey{}, err
+	}
+	if pk == ce.pk {
+		// SetRelayPeers drops self-nominations silently, which would leave the
+		// caller with a client that never attaches and no reason why.
+		return pk, fmt.Errorf("dmsg: local relay %s://%s has this client's own key %s", network, addr, pk)
+	}
+	ce.SetSessionDialer(d.SessionDialer())
+	ce.SetRelayPeers([]cipher.PubKey{pk}, port)
+	return pk, nil
+}

--- a/pkg/dmsg/dmsg/relay_local_test.go
+++ b/pkg/dmsg/dmsg/relay_local_test.go
@@ -1,0 +1,194 @@
+package dmsg
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+func TestLocalRelayHelloRoundTrip(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+
+	var buf bytes.Buffer
+	require.NoError(t, writeLocalRelayHello(&buf, pk, 70))
+	require.Equal(t, localRelayHelloLen, buf.Len())
+
+	gotPK, gotPort, err := readLocalRelayHello(&buf)
+	require.NoError(t, err)
+	require.Equal(t, pk, gotPK)
+	require.Equal(t, uint16(70), gotPort)
+}
+
+func TestLocalRelayHelloRejects(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	good := new(bytes.Buffer)
+	require.NoError(t, writeLocalRelayHello(good, pk, 70))
+
+	t.Run("bad magic", func(t *testing.T) {
+		b := append([]byte(nil), good.Bytes()...)
+		b[0] = 'X'
+		_, _, err := readLocalRelayHello(bytes.NewReader(b))
+		require.ErrorIs(t, err, ErrLocalRelayHello)
+	})
+	t.Run("bad version", func(t *testing.T) {
+		b := append([]byte(nil), good.Bytes()...)
+		b[len(localRelayMagic)] = 99
+		_, _, err := readLocalRelayHello(bytes.NewReader(b))
+		require.ErrorIs(t, err, ErrLocalRelayHello)
+	})
+	t.Run("short", func(t *testing.T) {
+		_, _, err := readLocalRelayHello(bytes.NewReader(good.Bytes()[:4]))
+		require.ErrorIs(t, err, ErrLocalRelayHello)
+	})
+	t.Run("null key", func(t *testing.T) {
+		var null bytes.Buffer
+		require.NoError(t, writeLocalRelayHello(&null, cipher.PubKey{}, 70))
+		_, _, err := readLocalRelayHello(&null)
+		require.ErrorIs(t, err, ErrLocalRelayHello)
+	})
+}
+
+// newLocalRelayTestClient makes a client whose discovery lists NO servers —
+// the shape a standalone attached process runs with: nothing to register,
+// nowhere else to go, only the relay.
+func newLocalRelayTestClient(t *testing.T, name string, relayOnly bool, maxRelayed int) (*Client, cipher.PubKey) {
+	t.Helper()
+	pk, sk := GenKeyPair(t, name)
+	log := logging.MustGetLogger(name)
+	c := NewClient(pk, sk, entryOnlyDisc{disc.NewMock(0)}, &Config{
+		MinSessions:       1,
+		RelayOnly:         relayOnly,
+		NoRegister:        true,
+		MaxRelayedStreams: maxRelayed,
+	})
+	c.SetLogger(log)
+	return c, pk
+}
+
+// TestAttachLocalRelay is the whole feature end to end over a real unix
+// socket: an acceptor client serving ServeLocalRelay, and a second client that
+// attaches to it with AttachLocalRelay and ends up holding exactly one
+// session — to the acceptor, on the skynet carrier — under its OWN key.
+func TestAttachLocalRelay(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "relay.sock")
+	lis, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+
+	relay, relayPK := newLocalRelayTestClient(t, "relay-acceptor", false, DefaultClientMaxRelayedStreams)
+	defer relay.Close() //nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	go func() {
+		_ = relay.ServeLocalRelay(ctx, lis, 70, nil) //nolint:errcheck
+	}()
+
+	attached, attachedPK := newLocalRelayTestClient(t, "attached-client", true, 0)
+	defer attached.Close() //nolint:errcheck
+
+	gotPK, err := attached.AttachLocalRelay(ctx, "unix", sock)
+	require.NoError(t, err)
+	require.Equal(t, relayPK, gotPK, "the hello must name the acceptor")
+
+	go attached.Serve(ctx)
+
+	select {
+	case <-attached.Ready():
+	case <-ctx.Done():
+		t.Fatal("attached client never became ready")
+	}
+
+	// Exactly one session, and it is the relay: this is what RelayOnly buys —
+	// no server sessions held, nothing published.
+	sessions := attached.AllSessions()
+	require.Len(t, sessions, 1)
+	require.Equal(t, relayPK, sessions[0].RemotePK())
+	require.Equal(t, CarrierSkynet, sessions[0].Carrier())
+
+	// The identity did NOT rotate: the acceptor sees the attaching client's
+	// own key, which is the entire point of attaching rather than proxying.
+	require.Eventually(t, func() bool {
+		for _, pk := range relay.RelaySessions() {
+			if pk == attachedPK {
+				return true
+			}
+		}
+		return false
+	}, 10*time.Second, 50*time.Millisecond)
+}
+
+// TestAttachLocalRelayRefused checks the allow callback is honored on the
+// local pipe exactly as it is on the skynet one: a key the acceptor refuses
+// gets its conn closed after the handshake, and never becomes a relay session.
+func TestAttachLocalRelayRefused(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "relay.sock")
+	lis, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+
+	relay, relayPK := newLocalRelayTestClient(t, "relay-acceptor", false, DefaultClientMaxRelayedStreams)
+	defer relay.Close() //nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	go func() {
+		_ = relay.ServeLocalRelay(ctx, lis, 70, func(cipher.PubKey) bool { return false }) //nolint:errcheck
+	}()
+
+	attached, _ := newLocalRelayTestClient(t, "attached-client", true, 0)
+	defer attached.Close() //nolint:errcheck
+
+	// The probe still succeeds: the hello is written before the handshake, so
+	// the acceptor's identity is readable by anyone who can open the socket.
+	// Admission is decided later, on proof of key.
+	gotPK, err := attached.AttachLocalRelay(ctx, "unix", sock)
+	require.NoError(t, err)
+	require.Equal(t, relayPK, gotPK)
+
+	go attached.Serve(ctx)
+
+	require.Never(t, func() bool {
+		return len(relay.RelaySessions()) > 0
+	}, 3*time.Second, 100*time.Millisecond)
+}
+
+func TestLocalRelayDialerWrongPeer(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "relay.sock")
+	lis, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+
+	relay, _ := newLocalRelayTestClient(t, "relay-acceptor", false, DefaultClientMaxRelayedStreams)
+	defer relay.Close() //nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	go func() {
+		_ = relay.ServeLocalRelay(ctx, lis, 70, nil) //nolint:errcheck
+	}()
+
+	// A socket that now fronts a different visor than the one nominated must
+	// fail loudly rather than hand the conn to a Noise handshake keyed to the
+	// wrong peer, which would hang until the handshake timeout.
+	other, _ := cipher.GenerateKeyPair()
+	d := LocalRelayDialer{Network: "unix", Addr: sock}
+	_, err = d.SessionDialer()(ctx, CarrierSkynet, SkynetAddr(other, 70))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expected")
+}
+
+func TestLocalRelaySessionDialerRejectsOtherCarriers(t *testing.T) {
+	d := LocalRelayDialer{Network: "unix", Addr: "/nonexistent.sock"}
+	_, err := d.SessionDialer()(context.Background(), CarrierTCP, "1.2.3.4:80")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported carrier")
+}

--- a/pkg/dmsg/dmsgc/spec/local_relay_test.go
+++ b/pkg/dmsg/dmsgc/spec/local_relay_test.go
@@ -1,0 +1,62 @@
+//go:build !js
+
+package spec
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestLocalRelay_RoundTrip verifies the visor-wide local_relay block survives
+// Unmarshal → Marshal in the single-object shape and is omitted when unset.
+//
+// It is not a formality: DmsgConfig has a HAND-WRITTEN codec (spec_native.go),
+// and a `json` tag on the struct field alone buys nothing — a field the codec
+// does not name is dropped silently on read AND on write, which for an opt-in
+// security-relevant acceptor would read to the operator as "the feature does
+// not work" with nothing in the logs.
+func TestLocalRelay_RoundTrip(t *testing.T) {
+	const raw = `{"discovery":"http://disc.example","local_relay":{"enabled":true,"socket":"/run/skywire/relay.sock","socket_mode":"0660","allowed_keys":["024ec47420176680816e0406250e7156465e4531f5b26057c9f6297bb0303558c7"]}}`
+
+	var c DmsgConfig
+	if err := json.Unmarshal([]byte(raw), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.LocalRelay == nil {
+		t.Fatal("local_relay not parsed from JSON")
+	}
+	if !c.LocalRelay.Enabled {
+		t.Fatal("local_relay.enabled not parsed")
+	}
+	if c.LocalRelay.Socket != "/run/skywire/relay.sock" {
+		t.Fatalf("local_relay.socket = %q", c.LocalRelay.Socket)
+	}
+	if c.LocalRelay.SocketMode != "0660" {
+		t.Fatalf("local_relay.socket_mode = %q", c.LocalRelay.SocketMode)
+	}
+	if len(c.LocalRelay.AllowedKeys) != 1 {
+		t.Fatalf("local_relay.allowed_keys = %v", c.LocalRelay.AllowedKeys)
+	}
+
+	out, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, want := range []string{`"local_relay"`, `"enabled":true`, `"socket":"/run/skywire/relay.sock"`, `"socket_mode":"0660"`} {
+		if !strings.Contains(string(out), want) {
+			t.Fatalf("missing %s in %s", want, out)
+		}
+	}
+
+	// Unset is omitted: a generated config carries no acceptor, and the
+	// feature stays opt-in.
+	c.LocalRelay = nil
+	out, err = json.Marshal(c)
+	if err != nil {
+		t.Fatalf("marshal default: %v", err)
+	}
+	if strings.Contains(string(out), "local_relay") {
+		t.Fatalf("nil local_relay should be omitted: %s", out)
+	}
+}

--- a/pkg/dmsg/dmsgc/spec/spec.go
+++ b/pkg/dmsg/dmsgc/spec/spec.go
@@ -126,6 +126,63 @@ type DmsgConfig struct {
 	// dmsg.DefaultClientMaxRelayedStreams. A negative value refuses to relay at
 	// all, for a visor that should never carry other people's traffic.
 	RelayMaxStreams int `json:"relay_max_streams,omitempty"`
+
+	// LocalRelay, when non-nil AND Enabled, opens a LOCAL acceptor (unix
+	// socket, optionally a loopback listener) onto the same relay the visor
+	// already serves over skynet, so a standalone process on this host can
+	// hold a dmsg identity WITHOUT holding dmsg server sessions of its own.
+	// Nil (the default) = no local acceptor: this is a grant of the visor's
+	// sessions and transports, so it is opt-in. See DmsgLocalRelayConfig.
+	LocalRelay *DmsgLocalRelayConfig `json:"local_relay,omitempty"`
+}
+
+// DmsgLocalRelayConfig configures the visor's LOCAL dmsg relay acceptor
+// (dmsg.Client.ServeLocalRelay). Default off — the whole struct is nil in
+// generated configs.
+//
+// What it grants: a process that attaches here dials dmsg under ITS OWN key,
+// but its streams are forwarded over THIS visor's dmsg sessions and transports
+// and are charged to this visor's relay slots (dmsg.relay_max_streams). The
+// attached key never rotates and never appears in dmsg-discovery.
+//
+// How it is authorized, in two independent layers:
+//
+//   - The listener. A unix socket at Socket, created with SocketMode (0600 by
+//     default), makes the filesystem the gate: only a process running as the
+//     visor's user can open it — and such a process can already read the
+//     visor's own secret key, so attaching grants it nothing new.
+//   - AllowedKeys. The dmsg session handshake is Noise XK, which PROVES the
+//     attaching process holds the secret key for the public key it claims, so
+//     an entry in this list is authentication and not a hint. Empty means "any
+//     key that can open the listener", which is the right default for a 0600
+//     socket and the wrong one for anything else.
+//
+// TCPAddress exists for the cases a unix socket cannot serve (a container
+// sharing the host's loopback but not its filesystem, Windows). It has no
+// filesystem gate, so it REQUIRES a non-empty AllowedKeys and a loopback
+// address; the visor refuses to bind it otherwise rather than quietly opening
+// an unauthenticated path to its own transports.
+type DmsgLocalRelayConfig struct {
+	// Enabled gates the whole acceptor. False (or a nil
+	// *DmsgLocalRelayConfig) = the visor serves no local relay.
+	Enabled bool `json:"enabled"`
+	// Socket is the unix socket path the acceptor listens on. Empty means
+	// "<local_path>/dmsg_relay.sock". Set it to "-" to run with no unix
+	// socket at all (TCPAddress only).
+	Socket string `json:"socket,omitempty"`
+	// SocketMode is the unix socket's file mode in octal, as a string
+	// ("0600", "0660"). Empty = "0600" (owner only). Widening it to a group
+	// mode is how an operator lets a service account that is NOT the visor's
+	// user attach; pair that with AllowedKeys, because the group is then the
+	// only thing standing between any of its members and this visor's
+	// transports.
+	SocketMode string `json:"socket_mode,omitempty"`
+	// TCPAddress is an optional loopback listen address ("127.0.0.1:7070").
+	// Empty = none. Requires AllowedKeys; a non-loopback host is refused.
+	TCPAddress string `json:"tcp_address,omitempty"`
+	// AllowedKeys, when non-empty, admits ONLY these public keys. Empty
+	// leaves the listener's own gate as the only one (see the type comment).
+	AllowedKeys []cipher.PubKey `json:"allowed_keys,omitempty"`
 }
 
 // DmsgServerConfig configures the OPTIONAL in-process dmsg server co-resident

--- a/pkg/dmsg/dmsgc/spec/spec_native.go
+++ b/pkg/dmsg/dmsgc/spec/spec_native.go
@@ -37,6 +37,12 @@ type deploymentWithServer struct {
 	// deployment in the single-object shape (like Server). See
 	// DmsgConfig.LookupCXO.
 	LookupCXO bool `json:"lookup_cxo,omitempty"`
+	// LocalRelay is visor-wide too (like Server): the local relay acceptor
+	// belongs to the client, not to any one deployment. Without this key
+	// here the field would be silently dropped on read AND on write — the
+	// custom codec below is the only one V1 uses for this struct, so a
+	// `json` tag on DmsgConfig alone buys nothing.
+	LocalRelay *DmsgLocalRelayConfig `json:"local_relay,omitempty"`
 }
 
 // UnmarshalJSON accepts either a single Deployment object or an
@@ -58,6 +64,7 @@ func (c *DmsgConfig) UnmarshalJSON(data []byte) error {
 		c.LookupCXO = single.LookupCXO
 		c.DirectOnly = single.DirectOnly
 		c.RelayMaxStreams = single.RelayMaxStreams
+		c.LocalRelay = single.LocalRelay
 	}
 	c.mirrorPrimary()
 	return nil
@@ -71,11 +78,18 @@ func (c *DmsgConfig) UnmarshalJSON(data []byte) error {
 // so the JSON output is correct.
 func (c DmsgConfig) MarshalJSON() ([]byte, error) {
 	deployments := c.Deployments
-	if len(deployments) == 0 && (c.Discovery != "" || c.DiscoveryDmsg != "" || len(c.Servers) > 0 || c.SessionsCount != 0 || c.ConnectedServersType != "" || c.Protocol != "" || len(c.Carriers) > 0 || len(c.LANServers) > 0 || c.HypervisorDiscovery != "" || c.Server != nil) {
+	if len(deployments) == 0 && (c.Discovery != "" || c.DiscoveryDmsg != "" || len(c.Servers) > 0 || c.SessionsCount != 0 || c.ConnectedServersType != "" || c.Protocol != "" || len(c.Carriers) > 0 || len(c.LANServers) > 0 || c.HypervisorDiscovery != "" || c.Server != nil || c.LocalRelay != nil) {
 		deployments = []Deployment{c.toDeployment()}
 	}
 	if len(deployments) == 1 {
-		return json.Marshal(deploymentWithServer{Deployment: deployments[0], Server: c.Server, LookupCXO: c.LookupCXO, DirectOnly: c.DirectOnly, RelayMaxStreams: c.RelayMaxStreams})
+		return json.Marshal(deploymentWithServer{
+			Deployment:      deployments[0],
+			Server:          c.Server,
+			LookupCXO:       c.LookupCXO,
+			DirectOnly:      c.DirectOnly,
+			RelayMaxStreams: c.RelayMaxStreams,
+			LocalRelay:      c.LocalRelay,
+		})
 	}
 	return json.Marshal(deployments)
 }

--- a/pkg/dmsg/dmsgclient/cli.go
+++ b/pkg/dmsg/dmsgclient/cli.go
@@ -58,6 +58,16 @@ Default mode of operation is dmsghttp:
 
 // InitDmsgWithFlags starts dmsg with flags from the flags package
 func InitDmsgWithFlags(ctx context.Context, dlog *logging.Logger, pk cipher.PubKey, sk cipher.SecKey, httpClient *http.Client, destination string) (dmsgC *dmsg.Client, stop func(), err error) {
+	// --attach short-circuits every server-dialing mode below: an attached
+	// client holds no server session for --srv to pin, no discovery to reach
+	// over --disc-addr, and no use for the --direct seed set. It is checked
+	// FIRST so a stale server flag in someone's unit file cannot quietly put
+	// the process back on the servers it was moved off.
+	if DmsgAttach != "" {
+		network, addr := AttachTarget(DmsgAttach)
+		c, stopFn, _, err := StartDmsgLocalRelay(ctx, dlog, pk, sk, network, addr)
+		return c, stopFn, err
+	}
 	if DmsgServerAddr != "" {
 		srvEntry, err := ParseServerAddr(DmsgServerAddr)
 		if err != nil {

--- a/pkg/dmsg/dmsgclient/flags.go
+++ b/pkg/dmsg/dmsgclient/flags.go
@@ -37,7 +37,25 @@ var (
 	// DmsgServerAddr specifies a specific dmsg server to connect through.
 	// Format: pk@ip:port (e.g., 02a2d4c3...@45.79.124.73:30082)
 	DmsgServerAddr string
+
+	// DmsgAttach is the local visor dmsg-relay acceptor to attach to instead
+	// of dialing dmsg servers: a unix socket path, or "tcp://host:port" for a
+	// loopback listener. The tool keeps its own key — that is the whole point
+	// — and holds no server sessions and no discovery entry while attached.
+	// See StartDmsgLocalRelay.
+	DmsgAttach string
 )
+
+// AttachTarget splits DmsgAttach into (network, address). A bare path is a
+// unix socket — the default and the one with a filesystem gate; "tcp://" opts
+// into the loopback listener, which the visor only serves when it has an
+// explicit key allowlist.
+func AttachTarget(s string) (network, addr string) {
+	if rest, ok := strings.CutPrefix(s, "tcp://"); ok {
+		return "tcp", rest
+	}
+	return "unix", strings.TrimPrefix(s, "unix://")
+}
 
 // InitFlags is used to set command flags for the above variables.
 //
@@ -52,6 +70,7 @@ func InitFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&DmsgHTTPPath, "dmsgconf", "D", "", "dmsghttp-config path")
 	cmd.Flags().IntVarP(&DmsgSessions, "sess", "e", DmsgSessions, "number of DMSG Servers to connect to")
 	cmd.Flags().StringVarP(&DmsgServerAddr, "srv", "S", "", "connect via specific dmsg server `pk@ip:port`")
+	cmd.Flags().StringVar(&DmsgAttach, "attach", "", "attach to a local visor's dmsg relay `socket` (holds no server sessions, publishes no entry, keeps this key)")
 }
 
 // ParseServerAddr parses the --srv flag value into a disc.Entry.

--- a/pkg/dmsg/dmsgclient/local_relay.go
+++ b/pkg/dmsg/dmsgclient/local_relay.go
@@ -1,0 +1,104 @@
+//go:build !tinygo
+
+// Package dmsgclient pkg/dmsg/dmsgclient/local_relay.go c1-net-dmsg
+//
+// Bootstrap for a standalone dmsg client that ATTACHES to a visor on the same
+// host instead of dialing dmsg servers itself (dmsg.Client.AttachLocalRelay,
+// and pkg/visor/init_dmsg_relay_local.go for the other end).
+//
+// The point is the key. Every standalone tool here — dmsgweb, dmsg-socks5,
+// dmsghttp, curl — takes a --sk and runs under a fixed identity that something
+// else in the deployment already knows: a survey whitelist, a service PK
+// written into someone's config, a rewards record. Those keys cannot rotate, so
+// the usual answer to "this process should not hold its own server sessions"
+// (run it under an ephemeral key, or fold it into the visor) is not available.
+// Attaching keeps the key exactly as it is and moves only the transport.
+//
+// What changes for the process: one session instead of MinSessions (to the
+// visor over a unix socket), no discovery entry at all, and its streams
+// forwarded over the visor's sessions and transports. What does not change: the
+// key it dials under, the key destinations see, and the dmsg API it uses.
+package dmsgclient
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/direct"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// LocalRelayIdentity reads the acceptor's hello at network/addr and hangs up,
+// returning the visor's public key and the dmsg port its relay is published on.
+//
+// It creates no dmsg client and therefore no identity: "is there a relay
+// acceptor on this socket, and whose?" is a question an operator asks while
+// setting the socket up, and answering it must not mint a throwaway key.
+func LocalRelayIdentity(ctx context.Context, network, addr string) (cipher.PubKey, uint16, error) {
+	return dmsg.LocalRelayDialer{Network: network, Addr: addr}.PubKey(ctx)
+}
+
+// StartDmsgLocalRelay builds and serves a dmsg client attached to the local
+// visor's relay acceptor at network/addr ("unix" + socket path, or "tcp" + a
+// loopback address), and blocks until it holds the relay session or ctx ends.
+//
+// The client is RelayOnly and NoRegister, which together are what "attached"
+// means in practice:
+//
+//   - RelayOnly: once the relay session is up the serve loop is satisfied by it
+//     and stops looking for servers, so this process holds exactly one session
+//     — and it is the visor beside it, not a slot on a shared dmsg server.
+//   - NoRegister: nothing to publish. A discovery entry names the servers a
+//     client sits on so peers can rendezvous there; an attached client sits on
+//     none, and peers reach it through the relay. Publishing an entry naming
+//     nothing would be worse than publishing none: it is what a peer would
+//     resolve and then fail to use.
+//
+// The discovery client is an EMPTY direct client rather than a real one. It is
+// not a stub for something missing — it is the correct discovery for a process
+// that neither registers nor resolves: DialStream tries relay sessions before
+// any lookup (see client_dial.go's phase 0), so destinations are reached over
+// the relay, which does its own resolution with the visor's entry cache and the
+// visor's sessions. Handing this client a live discovery instead would make it
+// dial dmsg-discovery over the relay on every lookup to answer a question the
+// relay already answered.
+//
+// It returns the client, a stop func, and the visor's public key.
+func StartDmsgLocalRelay(ctx context.Context, dlog *logging.Logger, pk cipher.PubKey, sk cipher.SecKey, network, addr string) (*dmsg.Client, func(), cipher.PubKey, error) {
+	if dlog == nil {
+		return nil, nil, cipher.PubKey{}, fmt.Errorf("nil logger")
+	}
+	dmsgC := dmsg.NewClient(pk, sk, direct.NewClient(nil, dlog), &dmsg.Config{
+		MinSessions: 1,
+		RelayOnly:   true,
+		NoRegister:  true,
+		ClientType:  "attached",
+	})
+	dmsgC.SetLogger(dlog)
+
+	relayPK, err := dmsgC.AttachLocalRelay(ctx, network, addr)
+	if err != nil {
+		_ = dmsgC.Close() //nolint:errcheck
+		return nil, nil, cipher.PubKey{}, fmt.Errorf("dmsg local relay attach: %w", err)
+	}
+
+	go dmsgC.Serve(ctx)
+
+	stop := func() {
+		if err := dmsgC.Close(); err != nil {
+			dlog.WithError(err).Debug("Disconnected from the local dmsg relay.")
+		}
+	}
+	dlog.WithField("relay", relayPK.String()).WithField("addr", network+"://"+addr).
+		Debug("Attaching to the local dmsg relay...")
+	select {
+	case <-ctx.Done():
+		stop()
+		return nil, nil, cipher.PubKey{}, ctx.Err()
+	case <-dmsgC.Ready():
+		dlog.WithField("relay", relayPK.String()).Debug("Attached to the local dmsg relay.")
+		return dmsgC, stop, relayPK, nil
+	}
+}

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -278,6 +278,10 @@ func initDmsg(ctx context.Context, v *Visor, log *logging.Logger) (err error) {
 	v.initLock.Unlock()
 	// The other half of the skynet carrier: serve attached peers as a dmsg relay.
 	v.initDmsgRelay(ctx, dmsgC)
+	// ...and the LOCAL half: a standalone process on this host attaching to the
+	// same relay over a unix socket (init_dmsg_relay_local.go). Opt-in; a nil
+	// dmsg.local_relay config binds nothing.
+	v.initLocalDmsgRelay(ctx, dmsgC)
 	go v.nominateRelayPeers(ctx, dmsgC, log)
 	select {
 	case <-v.dmsgHTTPReady:

--- a/pkg/visor/init_dmsg_relay_local.go
+++ b/pkg/visor/init_dmsg_relay_local.go
@@ -1,0 +1,274 @@
+// Package visor pkg/visor/init_dmsg_relay_local.go c3-vis-core
+//
+// The LOCAL dmsg relay acceptor: the third pipe into the same relay
+// init_dmsg_relay.go already serves over skynet, and the only one that does not
+// involve the network at all.
+//
+// It exists for the standalone dmsg client that has to keep its key. The
+// dmsgweb proxy is the case that forced it: it runs beside the visor under a
+// key the survey whitelist knows, so rotating the key is not an option, and yet
+// every one of those processes holds its own sessions to dmsg servers and
+// publishes its own discovery entry — a whole second client's worth of server
+// capacity, per process, on a host that already has a visor with sessions and
+// transports. Attached here it keeps the key, holds exactly one session (to
+// this visor, over a unix socket), publishes nothing, and its streams ride this
+// visor's sessions.
+//
+// AUTHORIZATION — read dmsg.DmsgLocalRelayConfig's comment for the full model.
+// In short: the unix socket's 0600 mode means the attacher is already running
+// as the visor's user, which is a process that could read the visor's secret
+// key off disk anyway; and the optional allowed_keys list is real
+// authentication, because the dmsg session handshake is Noise XK and proves the
+// attacher holds the secret key for the PK it claims. The loopback listener has
+// no filesystem gate, so it is refused unless allowed_keys is non-empty.
+package visor
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgc/spec"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/util/osutil"
+)
+
+const (
+	// defaultLocalRelaySocketName is the unix socket the local relay acceptor
+	// binds under the visor's local_path when dmsg.local_relay.socket is
+	// unset.
+	defaultLocalRelaySocketName = "dmsg_relay.sock"
+
+	// defaultLocalRelaySocketMode is the socket's file mode when
+	// dmsg.local_relay.socket_mode is unset: owner only. This is the gate —
+	// see the package comment — so it is deliberately not 0666 and not 0660.
+	defaultLocalRelaySocketMode os.FileMode = 0600
+
+	// localRelaySocketDirMode is the mode the socket's PARENT directory is
+	// created with. net.Listen("unix") creates the socket file with
+	// 0777&^umask and there is no way to hand it a mode up front, so between
+	// the bind and the chmod below the socket is briefly whatever the umask
+	// allows. A 0700 directory closes that window: an unreachable path cannot
+	// be connected to whatever the file's own bits say for those few
+	// microseconds.
+	localRelaySocketDirMode os.FileMode = 0700
+
+	// maxUnixSocketPath is the shortest sockaddr_un.sun_path across the
+	// platforms this runs on (104 on the BSDs/macOS, 108 on Linux, both
+	// including the NUL). Used only to turn a bare EINVAL into a message that
+	// names the actual problem.
+	maxUnixSocketPath = 103
+)
+
+// initLocalDmsgRelay binds the configured local relay acceptor(s) and serves
+// each as a dmsg relay on dmsgC. No config (the default) means no listener.
+//
+// Errors bind-time rather than at first attach: a misconfigured socket path or
+// an unauthenticated loopback listener must be loud at boot, not a silent
+// missing feature discovered when the attaching process cannot connect. They
+// are logged and skipped rather than failing visor startup — a relay acceptor
+// nobody has attached to yet is not worth refusing to boot over.
+func (v *Visor) initLocalDmsgRelay(ctx context.Context, dmsgC *dmsg.Client) {
+	if v.conf == nil || v.conf.Dmsg == nil {
+		return
+	}
+	conf := v.conf.Dmsg.LocalRelay
+	if conf == nil || !conf.Enabled {
+		return
+	}
+	log := v.MasterLogger().PackageLogger("dmsg_relay_local")
+
+	allow, err := localRelayAllow(conf, v.conf.PK)
+	if err != nil {
+		log.WithError(err).Error("dmsg local relay disabled")
+		return
+	}
+
+	if sock := localRelaySocketPath(conf, v.conf.LocalPath); sock != "" {
+		if lis, err := listenLocalRelaySocket(sock, conf.SocketMode); err != nil {
+			log.WithError(err).WithField("socket", sock).Error("dmsg local relay: unix listener failed")
+		} else {
+			log.WithField("socket", sock).WithField("allowed_keys", len(conf.AllowedKeys)).
+				Info("dmsg local relay listening")
+			v.serveLocalRelay(ctx, dmsgC, lis, allow, log)
+		}
+	}
+
+	if conf.TCPAddress != "" {
+		if err := checkLocalRelayTCP(conf); err != nil {
+			log.WithError(err).WithField("tcp_address", conf.TCPAddress).
+				Error("dmsg local relay: loopback listener refused")
+		} else if lis, err := net.Listen("tcp", conf.TCPAddress); err != nil {
+			log.WithError(err).WithField("tcp_address", conf.TCPAddress).
+				Error("dmsg local relay: loopback listener failed")
+		} else {
+			log.WithField("tcp_address", conf.TCPAddress).WithField("allowed_keys", len(conf.AllowedKeys)).
+				Info("dmsg local relay listening")
+			v.serveLocalRelay(ctx, dmsgC, lis, allow, log)
+		}
+	}
+}
+
+// serveLocalRelay runs one acceptor and registers its shutdown. The listener is
+// closed on the close stack as well as on ctx: a unix socket left bound holds
+// its path, and the NEXT visor start would have to unlink a live-looking
+// socket to get it back.
+func (v *Visor) serveLocalRelay(ctx context.Context, dmsgC *dmsg.Client, lis net.Listener, allow func(cipher.PubKey) bool, log *logging.Logger) {
+	go func() {
+		if err := dmsgC.ServeLocalRelay(ctx, lis, skyenv.DmsgRelayPort, allow); err != nil {
+			log.WithError(err).Warn("dmsg local relay acceptor stopped")
+		}
+	}()
+	v.pushCloseStack("dmsg_relay_local", func() error {
+		return lis.Close()
+	})
+}
+
+// localRelaySocketPath resolves the unix socket path: the configured one, the
+// default under the visor's local_path, or "" when the operator set "-" to run
+// with the loopback listener only.
+func localRelaySocketPath(conf *spec.DmsgLocalRelayConfig, localPath string) string {
+	switch conf.Socket {
+	case "-":
+		return ""
+	case "":
+		if localPath == "" {
+			localPath = skyenv.LocalPath
+		}
+		return filepath.Join(localPath, defaultLocalRelaySocketName)
+	default:
+		return conf.Socket
+	}
+}
+
+// listenLocalRelaySocket binds the unix socket with the configured mode.
+//
+// The stale-socket unlink is the same one the dmsgpty CLI listener does: a
+// visor killed without running its close stack leaves the path behind, and
+// bind() on an existing path is EADDRINUSE whether or not anything is
+// listening. Unlinking is safe here because the path is the visor's own and a
+// second visor sharing one local_path is already broken for other reasons.
+func listenLocalRelaySocket(path string, mode string) (net.Listener, error) {
+	fileMode, err := parseSocketMode(mode)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), localRelaySocketDirMode); err != nil {
+		return nil, fmt.Errorf("failed to prepare directory for dmsg local relay socket: %w", err)
+	}
+	if err := osutil.UnlinkSocketFiles(path); err != nil {
+		return nil, fmt.Errorf("failed to unlink stale dmsg local relay socket: %w", err)
+	}
+	lis, err := net.Listen("unix", path)
+	if err != nil {
+		// A unix socket path is bounded by sockaddr_un.sun_path (107 usable
+		// bytes on Linux, fewer on the BSDs), and exceeding it fails with a
+		// bare EINVAL — "invalid argument" — which reads like a bug in the
+		// config parser rather than a path that is simply too long. Say so.
+		if len(path) >= maxUnixSocketPath {
+			return nil, fmt.Errorf("failed to bind dmsg local relay socket (path is %d bytes; unix sockets allow about %d): %w", len(path), maxUnixSocketPath, err)
+		}
+		return nil, err
+	}
+	// Chmod AFTER bind — the socket file does not exist before it. See
+	// localRelaySocketDirMode for why the window this opens is closed by the
+	// parent directory rather than by ordering.
+	//
+	// A failure here is fatal to the listener, NOT a warning: the whole
+	// authorization story for a socket with no allowed_keys is its mode, and
+	// serving one whose mode is unknown would be exactly the
+	// unauthenticated local path this feature must not create.
+	if err := os.Chmod(path, fileMode); err != nil {
+		_ = lis.Close() //nolint:errcheck
+		return nil, fmt.Errorf("failed to set dmsg local relay socket mode: %w", err)
+	}
+	return lis, nil
+}
+
+// parseSocketMode parses an octal file-mode string ("0600"). Empty is the
+// default. It is a string in the config because JSON has no octal literal and
+// 0600 written as a JSON number is six hundred.
+func parseSocketMode(mode string) (os.FileMode, error) {
+	if mode == "" {
+		return defaultLocalRelaySocketMode, nil
+	}
+	m, err := strconv.ParseUint(mode, 8, 32)
+	if err != nil {
+		return 0, fmt.Errorf("dmsg.local_relay.socket_mode %q is not an octal file mode: %w", mode, err)
+	}
+	return os.FileMode(m), nil
+}
+
+// checkLocalRelayTCP refuses a loopback listener that would be an
+// unauthenticated path to this visor's transports.
+//
+// Two conditions, both load-bearing. A non-loopback bind address would expose
+// the acceptor to the network, where the only gate left is the key list — and a
+// key list is an allowlist, not a rate limit or a DoS defense. And with NO key
+// list there is no gate at all: unlike the unix socket, a TCP port carries no
+// evidence about who opened it, so every local user (and, on a shared network
+// namespace, every co-tenant container) could attach under any key it liked.
+func checkLocalRelayTCP(conf *spec.DmsgLocalRelayConfig) error {
+	if len(conf.AllowedKeys) == 0 {
+		return fmt.Errorf("dmsg.local_relay.tcp_address requires a non-empty allowed_keys: a TCP listener has no filesystem gate")
+	}
+	host, _, err := net.SplitHostPort(conf.TCPAddress)
+	if err != nil {
+		return fmt.Errorf("dmsg.local_relay.tcp_address %q is not a host:port: %w", conf.TCPAddress, err)
+	}
+	if host == "localhost" {
+		return nil
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("dmsg.local_relay.tcp_address %q must name a loopback IP (or localhost)", conf.TCPAddress)
+	}
+	if !ip.IsLoopback() {
+		return fmt.Errorf("dmsg.local_relay.tcp_address %q is not a loopback address", conf.TCPAddress)
+	}
+	return nil
+}
+
+// localRelayAllow builds the admission callback for the local acceptor — the
+// same func(cipher.PubKey) bool the skynet acceptor hands AcceptRelaySession,
+// consulted at the same point: after the Noise handshake has proven the peer's
+// key.
+//
+// It is deliberately NOT relayPeerAllowed. That callback answers a different
+// question — "is this REMOTE peer one we have a relationship with" — by
+// consulting the peer whitelist, the visors we manage, and the transports we
+// hold, none of which a local process has or needs. Here the listener is the
+// relationship; allowed_keys narrows it when the listener alone is not enough.
+//
+// The visor's own key is refused outright. Two dmsg clients sharing one key
+// evict each other from every server they share, which is a failure mode this
+// deployment has paid for before; the local relay must not be a new way to
+// arrange it.
+func localRelayAllow(conf *spec.DmsgLocalRelayConfig, selfPK cipher.PubKey) (func(cipher.PubKey) bool, error) {
+	allowed := make(map[cipher.PubKey]struct{}, len(conf.AllowedKeys))
+	for _, pk := range conf.AllowedKeys {
+		if pk.Null() {
+			return nil, fmt.Errorf("dmsg.local_relay.allowed_keys contains a null public key")
+		}
+		if pk == selfPK {
+			return nil, fmt.Errorf("dmsg.local_relay.allowed_keys contains this visor's own key %s", pk)
+		}
+		allowed[pk] = struct{}{}
+	}
+	return func(pk cipher.PubKey) bool {
+		if pk.Null() || pk == selfPK {
+			return false
+		}
+		if len(allowed) == 0 {
+			return true // the listener is the gate; see the package comment
+		}
+		_, ok := allowed[pk]
+		return ok
+	}, nil
+}

--- a/pkg/visor/init_dmsg_relay_local.go
+++ b/pkg/visor/init_dmsg_relay_local.go
@@ -57,6 +57,12 @@ const (
 	// allows. A 0700 directory closes that window: an unreachable path cannot
 	// be connected to whatever the file's own bits say for those few
 	// microseconds.
+	//
+	// It closes it only for a directory this visor CREATES, though —
+	// os.MkdirAll leaves an existing one alone, and the default path sits
+	// under local_path, which usually already exists. See
+	// warnIfLocalRelayDirPermissive for what is done about that and why it is
+	// a warning rather than a refusal.
 	localRelaySocketDirMode os.FileMode = 0700
 
 	// maxUnixSocketPath is the shortest sockaddr_un.sun_path across the
@@ -91,7 +97,7 @@ func (v *Visor) initLocalDmsgRelay(ctx context.Context, dmsgC *dmsg.Client) {
 	}
 
 	if sock := localRelaySocketPath(conf, v.conf.LocalPath); sock != "" {
-		if lis, err := listenLocalRelaySocket(sock, conf.SocketMode); err != nil {
+		if lis, err := listenLocalRelaySocket(sock, conf.SocketMode, log); err != nil {
 			log.WithError(err).WithField("socket", sock).Error("dmsg local relay: unix listener failed")
 		} else {
 			log.WithField("socket", sock).WithField("allowed_keys", len(conf.AllowedKeys)).
@@ -154,14 +160,31 @@ func localRelaySocketPath(conf *spec.DmsgLocalRelayConfig, localPath string) str
 // bind() on an existing path is EADDRINUSE whether or not anything is
 // listening. Unlinking is safe here because the path is the visor's own and a
 // second visor sharing one local_path is already broken for other reasons.
-func listenLocalRelaySocket(path string, mode string) (net.Listener, error) {
+func listenLocalRelaySocket(path string, mode string, log *logging.Logger) (net.Listener, error) {
 	fileMode, err := parseSocketMode(mode)
 	if err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(filepath.Dir(path), localRelaySocketDirMode); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, localRelaySocketDirMode); err != nil {
 		return nil, fmt.Errorf("failed to prepare directory for dmsg local relay socket: %w", err)
 	}
+	// MkdirAll applies its mode only to directories it CREATES. A pre-existing
+	// parent — the common case, since the default path sits under the visor's
+	// local_path — keeps whatever mode it already had, so the window-closing
+	// property described on localRelaySocketDirMode is not guaranteed and has
+	// to be checked rather than assumed. Observed in practice: ~/.skywire
+	// already existed as 0705, world-traversable.
+	//
+	// This is a narrow concern, not a hole: the socket's FINAL mode is 0600
+	// either way, and connecting to a unix socket needs write permission, so
+	// under the usual umask 022 the file is 0755 for the few microseconds
+	// before the chmod and nobody else can connect to it even then. It only
+	// bites under a permissive umask (002/000), where those bytes are 0775 or
+	// 0777. Warn rather than fail: the operator may have deliberately relaxed
+	// the directory, and refusing to serve would be a worse answer than
+	// naming the exposure.
+	warnIfLocalRelayDirPermissive(dir, log)
 	if err := osutil.UnlinkSocketFiles(path); err != nil {
 		return nil, fmt.Errorf("failed to unlink stale dmsg local relay socket: %w", err)
 	}
@@ -271,4 +294,22 @@ func localRelayAllow(conf *spec.DmsgLocalRelayConfig, selfPK cipher.PubKey) (fun
 		_, ok := allowed[pk]
 		return ok
 	}, nil
+}
+
+// warnIfLocalRelayDirPermissive logs when the socket's parent directory is
+// reachable by group or other, which weakens the bind→chmod window described in
+// listenLocalRelaySocket. Best-effort: a stat failure is not worth failing the
+// listener over, since the socket's own 0600 remains the operative gate.
+func warnIfLocalRelayDirPermissive(dir string, log *logging.Logger) {
+	fi, err := os.Stat(dir)
+	if err != nil {
+		return
+	}
+	if perm := fi.Mode().Perm(); perm&0o077 != 0 {
+		log.WithField("dir", dir).
+			WithField("mode", fmt.Sprintf("%#o", perm)).
+			Warnf("dmsg local-relay socket directory is reachable by group/other; "+
+				"the socket itself is %#o so this is only exposed under a permissive umask, "+
+				"but chmod 0700 %s closes it entirely", defaultLocalRelaySocketMode, dir)
+	}
 }

--- a/pkg/visor/init_dmsg_relay_local_test.go
+++ b/pkg/visor/init_dmsg_relay_local_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgc/spec"
+	"github.com/skycoin/skywire/pkg/logging"
 )
 
 func TestLocalRelaySocketPath(t *testing.T) {
@@ -43,7 +44,7 @@ func TestParseSocketMode(t *testing.T) {
 // gate on a grant of the visor's transports.
 func TestListenLocalRelaySocketMode(t *testing.T) {
 	sock := filepath.Join(t.TempDir(), "sub", "relay.sock")
-	lis, err := listenLocalRelaySocket(sock, "")
+	lis, err := listenLocalRelaySocket(sock, "", logging.MustGetLogger("test"))
 	require.NoError(t, err)
 	defer lis.Close() //nolint:errcheck
 
@@ -66,7 +67,7 @@ func TestListenLocalRelaySocketReplacesStale(t *testing.T) {
 	sock := filepath.Join(t.TempDir(), "relay.sock")
 	require.NoError(t, os.WriteFile(sock, nil, 0600))
 
-	lis, err := listenLocalRelaySocket(sock, "")
+	lis, err := listenLocalRelaySocket(sock, "", logging.MustGetLogger("test"))
 	require.NoError(t, err)
 	defer lis.Close() //nolint:errcheck
 

--- a/pkg/visor/init_dmsg_relay_local_test.go
+++ b/pkg/visor/init_dmsg_relay_local_test.go
@@ -1,0 +1,127 @@
+package visor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgc/spec"
+)
+
+func TestLocalRelaySocketPath(t *testing.T) {
+	require.Equal(t, filepath.Join("/var/lib/skywire", "dmsg_relay.sock"),
+		localRelaySocketPath(&spec.DmsgLocalRelayConfig{}, "/var/lib/skywire"))
+	require.Equal(t, "/run/skywire/relay.sock",
+		localRelaySocketPath(&spec.DmsgLocalRelayConfig{Socket: "/run/skywire/relay.sock"}, "/var/lib/skywire"))
+	// "-" opts out of the unix socket entirely (TCPAddress-only deployments).
+	require.Equal(t, "", localRelaySocketPath(&spec.DmsgLocalRelayConfig{Socket: "-"}, "/var/lib/skywire"))
+}
+
+func TestParseSocketMode(t *testing.T) {
+	m, err := parseSocketMode("")
+	require.NoError(t, err)
+	require.Equal(t, defaultLocalRelaySocketMode, m)
+
+	m, err = parseSocketMode("0660")
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0660), m)
+
+	// A decimal-looking "600" is still read as octal, which is what an
+	// operator writing a file mode means. A non-octal digit is an error
+	// rather than a silent 0.
+	_, err = parseSocketMode("0o600")
+	require.Error(t, err)
+	_, err = parseSocketMode("rw-------")
+	require.Error(t, err)
+}
+
+// TestListenLocalRelaySocketMode is the security-relevant one: the socket must
+// end up owner-only, because with no allowed_keys its file mode is the ONLY
+// gate on a grant of the visor's transports.
+func TestListenLocalRelaySocketMode(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "sub", "relay.sock")
+	lis, err := listenLocalRelaySocket(sock, "")
+	require.NoError(t, err)
+	defer lis.Close() //nolint:errcheck
+
+	fi, err := os.Stat(sock)
+	require.NoError(t, err)
+	require.Equal(t, defaultLocalRelaySocketMode, fi.Mode().Perm())
+
+	// The parent directory is the belt to that braces: net.Listen creates the
+	// socket with 0777&^umask and only then can it be chmodded.
+	di, err := os.Stat(filepath.Dir(sock))
+	require.NoError(t, err)
+	require.Equal(t, localRelaySocketDirMode, di.Mode().Perm())
+}
+
+// TestListenLocalRelaySocketReplacesStale covers the restart path: a visor
+// killed without running its close stack leaves the socket file behind, and
+// bind() on an existing path fails whether or not anything is listening — so
+// the second start must unlink before it binds.
+func TestListenLocalRelaySocketReplacesStale(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "relay.sock")
+	require.NoError(t, os.WriteFile(sock, nil, 0600))
+
+	lis, err := listenLocalRelaySocket(sock, "")
+	require.NoError(t, err)
+	defer lis.Close() //nolint:errcheck
+
+	fi, err := os.Stat(sock)
+	require.NoError(t, err)
+	require.NotZero(t, fi.Mode()&os.ModeSocket, "stale file should have been replaced by a socket")
+	require.Equal(t, defaultLocalRelaySocketMode, fi.Mode().Perm())
+}
+
+func TestCheckLocalRelayTCP(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+
+	// No key list: refused outright. A TCP listener carries no evidence about
+	// who opened it, so without allowed_keys there is no gate at all.
+	require.Error(t, checkLocalRelayTCP(&spec.DmsgLocalRelayConfig{TCPAddress: "127.0.0.1:7070"}))
+
+	ok := &spec.DmsgLocalRelayConfig{TCPAddress: "127.0.0.1:7070", AllowedKeys: []cipher.PubKey{pk}}
+	require.NoError(t, checkLocalRelayTCP(ok))
+	require.NoError(t, checkLocalRelayTCP(&spec.DmsgLocalRelayConfig{TCPAddress: "localhost:7070", AllowedKeys: []cipher.PubKey{pk}}))
+	require.NoError(t, checkLocalRelayTCP(&spec.DmsgLocalRelayConfig{TCPAddress: "[::1]:7070", AllowedKeys: []cipher.PubKey{pk}}))
+
+	// Anything reachable from off-host is refused even WITH a key list: an
+	// allowlist is not a DoS defense, and this feature must not become a
+	// network-exposed path to the visor's transports.
+	require.Error(t, checkLocalRelayTCP(&spec.DmsgLocalRelayConfig{TCPAddress: "0.0.0.0:7070", AllowedKeys: []cipher.PubKey{pk}}))
+	require.Error(t, checkLocalRelayTCP(&spec.DmsgLocalRelayConfig{TCPAddress: "192.168.1.5:7070", AllowedKeys: []cipher.PubKey{pk}}))
+	require.Error(t, checkLocalRelayTCP(&spec.DmsgLocalRelayConfig{TCPAddress: ":7070", AllowedKeys: []cipher.PubKey{pk}}))
+	require.Error(t, checkLocalRelayTCP(&spec.DmsgLocalRelayConfig{TCPAddress: "no-port", AllowedKeys: []cipher.PubKey{pk}}))
+}
+
+func TestLocalRelayAllow(t *testing.T) {
+	selfPK, _ := cipher.GenerateKeyPair()
+	listed, _ := cipher.GenerateKeyPair()
+	other, _ := cipher.GenerateKeyPair()
+
+	// Empty list: the listener is the gate, so any proven key is admitted —
+	// except the visor's own, which two clients must never share.
+	open, err := localRelayAllow(&spec.DmsgLocalRelayConfig{}, selfPK)
+	require.NoError(t, err)
+	require.True(t, open(listed))
+	require.True(t, open(other))
+	require.False(t, open(selfPK))
+	require.False(t, open(cipher.PubKey{}))
+
+	// With a list it is an allowlist, and the Noise handshake is what makes
+	// membership meaningful.
+	closed, err := localRelayAllow(&spec.DmsgLocalRelayConfig{AllowedKeys: []cipher.PubKey{listed}}, selfPK)
+	require.NoError(t, err)
+	require.True(t, closed(listed))
+	require.False(t, closed(other))
+	require.False(t, closed(selfPK))
+
+	// Config errors are refused at build time, not silently tolerated.
+	_, err = localRelayAllow(&spec.DmsgLocalRelayConfig{AllowedKeys: []cipher.PubKey{{}}}, selfPK)
+	require.Error(t, err)
+	_, err = localRelayAllow(&spec.DmsgLocalRelayConfig{AllowedKeys: []cipher.PubKey{selfPK}}, selfPK)
+	require.Error(t, err)
+}


### PR DESCRIPTION
A standalone dmsg client — its own keypair, its own binary, no router, no visor — can now attach to the visor beside it over a unix socket and hold a dmsg identity **without holding dmsg server sessions of its own**.

The motivating case is the dmsgweb proxy: it runs under a key the survey whitelist knows, so the key must not rotate, yet it costs the deployment a full client's worth of server sessions plus discovery-entry churn on every restart. Attached locally it keeps its key, holds exactly one session (to the visor), publishes no entry, and its streams ride the visor's sessions and transports — which that host is already paying for.

## Design

`AcceptRelaySession` was already transport-agnostic — it takes a plain `net.Conn` and preserves the attached peer's identity — so this is a **third pipe into the existing relay**, not a new mechanism. Deliberately no new carrier: the session stays `CarrierSkynet` at `skynet://<visorPK>:70`, so all 21 existing call sites work unchanged (`sessionsSatisfied`, `RelayOnly`'s exactly-one-session, `DialStream` phase 0, relay-slot accounting, `visor state`'s `relay_clients`). `Config.SessionDialer` exists precisely for a carrier the client cannot dial natively, and for a process with no router the local socket *is* its skynet dial.

The one wire addition is a 40-byte hello (`DRLY` + version + 33-byte PK + relay port) written before the session, because the handshake is Noise **XK**: the initiator must know the responder's static key up front. Without it every attaching tool would have to learn the visor's PK out of band and would get an opaque handshake hang when that guess went stale. `DialLocalRelay` verifies the hello's PK against the `skynet://` address, so a swapped socket fails loudly.

## Authorization

Opt-in (`dmsg.local_relay`, nil by default), two independent layers:

1. **The listener.** Unix socket `0600`. That gate is "a process running as the visor's user" — a process that could already read the visor's secret key off disk, so the grant adds nothing it did not have. A chmod failure is fatal to the listener, not a warning.
2. **`allowed_keys`**, the same `func(cipher.PubKey) bool` the skynet acceptor uses, consulted at the same point. Because the handshake is Noise XK, membership is cryptographic authentication rather than a hint.

`tcp_address` (for containers/Windows) has no filesystem gate, so the visor refuses to bind it unless `allowed_keys` is non-empty **and** the address is loopback — `0.0.0.0`, a LAN IP and a bare `:port` are all rejected even with a key list. There is no network-exposed unauthenticated path. The visor's own key is refused outright at both build and admission time: two dmsg clients on one key evict each other from every shared server.

## Verified on a live visor

```
$ skywire cli dmsg attach ~/.skywire/dmsg-local-relay.sock
visor:    0323272a…   port: 70

$ skywire cli dmsg attach … --sk <key>
attached: 03ddbd85…
session:  0323272a… (skynet)

$ skywire cli dmsg curl --attach … --sk <key> dmsg://0371ab4b…:80/health
{"service_name":"visor","version":"v1.3.93-375-gae1c659e4",…}
```

That last one is the whole point: an ephemeral standalone key, no server sessions, no discovery entry, fetching a remote visor across the network over this visor's transports.

## Second commit

Review caught an over-stated guarantee. `listenLocalRelaySocket` documented a 0700 parent as closing the gap between `net.Listen("unix")` (which creates the file `0777&^umask`) and the chmod after it — but `os.MkdirAll` applies its mode only to directories it *creates*, and the default path sits under `local_path`, which usually exists already. Live check: `~/.skywire` was `0705`.

Narrow rather than a hole, and the code now says so: the final mode is 0600 either way and a unix connect needs write permission, so under umask 022 the window leaves it at 0755 and nobody else can connect regardless. It bites only under umask 002/000. Warns rather than refuses, and the warning was confirmed firing against the real 0705 directory.

## Caveats

- `tcp_address` is covered by `checkLocalRelayTCP` tests only; no loopback listener was bound and attached to.
- Not exercised with dmsgweb itself, though `--attach` is on `dmsgclient.InitFlags`, which `cmd/dmsg/dmsgweb` uses.
- Windows cross-compiles, but unix-socket permissions carry no equivalent guarantee there; the config comment says to pair it with `allowed_keys`.
- **Latent bug found, deliberately not fixed:** `DmsgConfig`'s hand-written codec in `spec_native.go` never reads or writes `direct_only` or `relay_max_streams` despite their JSON tags, so those two are silently dropped from visor configs today. `local_relay` was added to the codec (with a test); fixing the other two would switch on behaviour that has been inert, which is a separate call. Separately, `pkg/skywireconfig/genvisor`'s marshaller emits no `DmsgConfig`-level keys at all — pre-existing and consistent.

`go build .`, `go vet`, and `go test` on `pkg/dmsg/...`, `pkg/visor/`, `pkg/dmsg/dmsgc/...`, `pkg/dmsg/dmsgclient/` all pass. `GOOS=windows` builds.