### PR TITLE
feat(dmsg): run the resolving proxy under its own key, attached in-process

### DIFF
--- a/pkg/dmsg/dmsg/relay_inproc.go
+++ b/pkg/dmsg/dmsg/relay_inproc.go
@@ -1,0 +1,105 @@
+// Package dmsg pkg/dmsg/dmsg/relay_inproc.go
+//
+// The IN-PROCESS attach: a second dmsg client in the same process as the first,
+// riding the first one's sessions. It is the third and cheapest pipe into the
+// relay (skynet in client_relay.go, a unix socket in relay_local.go, an
+// in-memory pipe here), and the only one with no I/O under it at all.
+//
+// What it is for: a visor that hosts a service which must answer under its OWN
+// key. The resolving dmsg/skynet proxy is the case that forced it — the survey
+// whitelist knows that key, so it cannot rotate, and it is not the visor's.
+// Before this the only ways to run it were a second full dmsg client (its own
+// sessions to every server, its own discovery entry, re-registered on every
+// restart — the identity churn that got the tpviz throwaway client deleted in
+// #4500/#4501) or a separate process attached over a unix socket, which is
+// machinery a co-located service does not need.
+//
+// Attached here the service keeps its key, holds exactly one session, publishes
+// nothing, and its streams ride the VISOR's sessions and transports. The host
+// pays for dmsg once.
+//
+// Why this is not the thing #4500/#4501 removed: that client registered. It
+// posted a discovery entry under a throwaway key and churned 660 identities in
+// fourteen days. A guest here is NoRegister by construction — it has no entry to
+// churn, and nothing dials it inbound except through its host. If a future
+// reader is about to delete this for the same reason that one went, that is the
+// difference to check first.
+//
+// AUTHORIZATION. There is no trust boundary to enforce: both clients are
+// constructed by the same process from the same config, so a guest can only
+// exist because the operator put its key in that config. The allow callback is
+// still threaded through — AcceptRelaySession takes one and the host may want
+// to bound which of its own guests attach — but it is a statement about
+// configuration, not a gate against an untrusted peer. That is the whole
+// difference from relay_local.go, where the socket IS the boundary.
+package dmsg
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// InProcessRelayDialer returns a SessionDialer that attaches the caller to
+// host's relay over an in-memory pipe.
+//
+// Each dial makes a net.Pipe, hands the host end to AcceptRelaySession on a
+// goroutine and returns the guest end. There is no hello preamble (relay_local
+// needs one only because a separate process cannot know the acceptor's key
+// before the Noise XK handshake; here the caller was handed the host client
+// itself) and no listener (nothing accepts — the dial IS the attach).
+//
+// The returned dialer refuses any carrier but skynet and any address but the
+// host's own, so a guest whose relay peers were repointed elsewhere fails
+// loudly instead of silently attaching to the wrong end of its own pipe.
+func (ce *Client) InProcessRelayDialer(ctx context.Context, allow func(cipher.PubKey) bool) SessionDialer {
+	return func(dialCtx context.Context, network, addr string) (net.Conn, error) {
+		if network != CarrierSkynet {
+			return nil, fmt.Errorf("dmsg in-process relay: unsupported carrier %q", network)
+		}
+		pk, _, err := ParseSkynetAddr(addr)
+		if err != nil {
+			return nil, err
+		}
+		if pk != ce.pk {
+			return nil, fmt.Errorf("dmsg in-process relay: address names %s, host is %s", pk, ce.pk)
+		}
+		hostEnd, guestEnd := net.Pipe()
+		go func() {
+			// ctx (the HOST's serving lifetime), not dialCtx: dialCtx is the
+			// guest's dial, which returns as soon as the session handshake
+			// completes. Tying the accept side to it would tear the session
+			// down the moment it came up.
+			if err := ce.AcceptRelaySession(ctx, hostEnd, allow); err != nil {
+				ce.log.WithError(err).Debug("dmsg in-process relay session ended with error")
+			}
+			_ = hostEnd.Close() //nolint:errcheck
+		}()
+		return guestEnd, nil
+	}
+}
+
+// AttachInProcess points guest at host's relay: guest holds one session, to
+// host, carried by an in-memory pipe. port is the relay port the synthetic
+// server entry advertises — it is never dialed, but SetRelayPeers builds the
+// entry from it and the dialer checks the key it names.
+//
+// Returns an error rather than attaching when the two clients share a key. Two
+// dmsg clients on one key evict each other from every server they share, and a
+// guest that is really its host is a configuration mistake worth naming at
+// startup instead of debugging later.
+func AttachInProcess(ctx context.Context, host, guest *Client, port uint16, allow func(cipher.PubKey) bool) error {
+	if host == nil || guest == nil {
+		return fmt.Errorf("dmsg in-process relay: nil client")
+	}
+	if host.pk == guest.pk {
+		return fmt.Errorf("dmsg in-process relay: guest shares the host's key %s", host.pk)
+	}
+	guest.SetSessionDialer(host.InProcessRelayDialer(ctx, allow))
+	if !guest.SetRelayPeers([]cipher.PubKey{host.pk}, port) {
+		return fmt.Errorf("dmsg in-process relay: host %s was not accepted as a relay peer", host.pk)
+	}
+	return nil
+}

--- a/pkg/dmsg/dmsg/relay_inproc_test.go
+++ b/pkg/dmsg/dmsg/relay_inproc_test.go
@@ -1,0 +1,85 @@
+// Package dmsg pkg/dmsg/dmsg/relay_inproc_test.go
+package dmsg
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A guest attached in-process holds exactly one session — to its host, over an
+// in-memory pipe — and the host sees the GUEST's own key. That identity is the
+// whole point: the resolving proxy answers under a key the survey whitelist
+// knows, while the host pays for dmsg once.
+func TestAttachInProcess(t *testing.T) {
+	host, hostPK := newLocalRelayTestClient(t, "inproc-host", false, DefaultClientMaxRelayedStreams)
+	defer host.Close() //nolint:errcheck
+
+	guest, guestPK := newLocalRelayTestClient(t, "inproc-guest", true, 0)
+	defer guest.Close() //nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	require.NoError(t, AttachInProcess(ctx, host, guest, 70, nil))
+
+	go guest.Serve(ctx)
+
+	select {
+	case <-guest.Ready():
+	case <-ctx.Done():
+		t.Fatal("in-process guest never became ready")
+	}
+
+	sessions := guest.AllSessions()
+	require.Len(t, sessions, 1, "a guest holds exactly one session: its host")
+	require.Equal(t, hostPK, sessions[0].RemotePK())
+	require.Equal(t, CarrierSkynet, sessions[0].Carrier())
+
+	require.Eventually(t, func() bool {
+		for _, pk := range host.RelaySessions() {
+			if pk == guestPK {
+				return true
+			}
+		}
+		return false
+	}, 10*time.Second, 50*time.Millisecond,
+		"the host must see the guest under the guest's OWN key")
+}
+
+func TestAttachInProcessRejects(t *testing.T) {
+	host, hostPK := newLocalRelayTestClient(t, "inproc-host-2", false, DefaultClientMaxRelayedStreams)
+	defer host.Close() //nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	t.Run("nil client", func(t *testing.T) {
+		require.Error(t, AttachInProcess(ctx, host, nil, 70, nil))
+	})
+
+	// Two dmsg clients on one key evict each other from every shared server,
+	// so a guest that is really its host is named at startup, not debugged.
+	t.Run("guest shares the host key", func(t *testing.T) {
+		err := AttachInProcess(ctx, host, host, 70, nil)
+		require.ErrorContains(t, err, "shares the host's key")
+	})
+
+	// The dialer refuses anything that is not this host over skynet, so a
+	// guest whose relay peers were repointed fails loudly.
+	t.Run("dialer refuses another carrier", func(t *testing.T) {
+		d := host.InProcessRelayDialer(ctx, nil)
+		_, err := d(ctx, "tcp", SkynetAddr(hostPK, 70))
+		require.ErrorContains(t, err, "unsupported carrier")
+	})
+
+	t.Run("dialer refuses another host", func(t *testing.T) {
+		other, otherPK := newLocalRelayTestClient(t, "inproc-other", true, 0)
+		defer other.Close() //nolint:errcheck
+		d := host.InProcessRelayDialer(ctx, nil)
+		_, err := d(ctx, CarrierSkynet, SkynetAddr(otherPK, 70))
+		require.ErrorContains(t, err, "host is")
+	})
+}

--- a/pkg/visor/embedded_dmsgweb.go
+++ b/pkg/visor/embedded_dmsgweb.go
@@ -31,12 +31,14 @@ import (
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/app/launcher"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/direct"
 	dmsgdisc "github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	dmsgspec "github.com/skycoin/skywire/pkg/dmsg/dmsgc/spec"
 	"github.com/skycoin/skywire/pkg/dmsgweb"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/proxystatus"
+	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
@@ -501,8 +503,21 @@ func initEmbeddedDmsgWeb(ctx context.Context, v *Visor, log *logging.Logger) err
 			Info("Auto-chaining dmsgweb → skynetweb for unified proxy")
 	}
 
+	// Run under the configured key when one is set, borrowing the visor's
+	// client otherwise. A failure here is not fatal: falling back to the
+	// visor's identity keeps the resolver working, and the log says the
+	// identity is not the configured one — which is the part an operator has
+	// to know, since the survey whitelist is keyed on it.
+	resolverC, resolverPK := v.dmsgC, v.conf.PK
+	if guest, guestPK, err := v.dmsgWebGuestClient(ctx, cfg, log); err != nil {
+		log.WithError(err).Error("dmsg_web secret_key configured but its client could not be attached; " +
+			"falling back to the visor's identity")
+	} else if guest != nil {
+		resolverC, resolverPK = guest, guestPK
+	}
+
 	aliases, dmsgSet := resolverAliasesAndDmsgServers(v)
-	runtime := newEmbeddedDmsgWeb(ctx, v.dmsgC, v.dmsgDC, v.conf.PK, v.services.SelfDial, v.services.SelfDialAs, aliases, dmsgSet, cfg, log)
+	runtime := newEmbeddedDmsgWeb(ctx, resolverC, v.dmsgDC, resolverPK, v.services.SelfDial, v.services.SelfDialAs, aliases, dmsgSet, cfg, log)
 	runtime.statusProvider = v.proxyStatusProvider()
 	v.initLock.Lock()
 	v.embeddedDmsgWeb = runtime
@@ -546,4 +561,46 @@ func buildDmsgWebAppFunc(rt *EmbeddedDmsgWeb, log *logging.Logger) appcommon.App
 		appCl.SetStatusOrLog(appserver.AppDetailedStatusStopped)
 		return nil
 	}
+}
+
+// dmsgWebGuestClient builds the resolver's own dmsg client when
+// dmsg_web.secret_key is set, attached in-process to the visor's relay.
+//
+// Returns (nil, zero, nil) when no key is configured — the common case, where
+// the resolver borrows the visor's client and answers as the visor.
+//
+// The guest is RelayOnly + NoRegister: one session, to this visor, over an
+// in-memory pipe, and no discovery entry. That is what separates it from the
+// second full dmsg client this replaces — see dmsg.AttachInProcess for why a
+// registering guest is the thing that got removed in #4500/#4501 and this is
+// not it.
+func (v *Visor) dmsgWebGuestClient(ctx context.Context, cfg *visorconfig.DmsgWebConfig, log *logging.Logger) (*dmsg.Client, cipher.PubKey, error) {
+	if cfg == nil || cfg.SecretKey == nil || *cfg.SecretKey == (cipher.SecKey{}) {
+		return nil, cipher.PubKey{}, nil
+	}
+	sk := *cfg.SecretKey
+	pk, err := sk.PubKey()
+	if err != nil {
+		return nil, cipher.PubKey{}, fmt.Errorf("invalid dmsg_web.secret_key: %w", err)
+	}
+
+	glog := v.MasterLogger().PackageLogger("dmsg_web_identity")
+	guest := dmsg.NewClient(pk, sk, direct.NewClient(nil, glog), &dmsg.Config{
+		MinSessions: 1,
+		RelayOnly:   true,
+		NoRegister:  true,
+		ClientType:  "resolver",
+	})
+	guest.SetLogger(glog)
+
+	if err := dmsg.AttachInProcess(ctx, v.dmsgC, guest, skyenv.DmsgRelayPort, nil); err != nil {
+		_ = guest.Close() //nolint:errcheck
+		return nil, cipher.PubKey{}, err
+	}
+	go guest.Serve(ctx)
+	v.pushCloseStack("dmsg_web_identity", guest.Close)
+
+	log.WithField("resolver_pk", pk).WithField("host_pk", v.conf.PK).
+		Info("Resolver running under its own dmsg identity, attached in-process to this visor")
+	return guest, pk, nil
 }

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -306,6 +306,25 @@ type RewardsConfig struct {
 type DmsgWebConfig struct {
 	// Enable must be true for the resolver to start.
 	Enable bool `json:"enable"`
+	// SecretKey runs the resolver under its OWN dmsg identity instead of the
+	// visor's. Unset (the default) keeps today's behaviour: the resolver
+	// borrows v.dmsgC and answers as the visor.
+	//
+	// It exists because some keys cannot move. The survey whitelist knows the
+	// key the resolving proxy runs under, so rotating it means updating the
+	// deployment; but running a second FULL dmsg client to hold that key
+	// costs its own sessions to every server and its own discovery entry,
+	// re-registered on every restart — the identity churn that got the tpviz
+	// throwaway client removed in #4500/#4501.
+	//
+	// Set here, the resolver's client is attached IN-PROCESS to the visor's
+	// own relay (dmsg.AttachInProcess): one session, over an in-memory pipe,
+	// no discovery entry, and every stream carried by the visor's sessions
+	// and transports. The host pays for dmsg once and the key never rotates.
+	//
+	// Nothing dials this key inbound except through the visor, so it suits an
+	// outbound resolver and NOT a service that must be reachable on its own.
+	SecretKey *cipher.SecKey `json:"secret_key,omitempty"`
 	// ProxyPort is the local SOCKS5 listener. Default 4445.
 	ProxyPort uint `json:"proxy_port,omitempty"`
 	// ProxyAddr is the host the SOCKS5 proxy binds to. Empty = loopback


### PR DESCRIPTION
Some keys cannot move. The survey whitelist knows the key the resolving dmsg/skynet proxy answers under, so rotating it means updating the deployment. Until now the only ways to hold that key were a second **full** dmsg client — its own sessions to every server, its own discovery entry, re-registered on every restart — or a separate process attached over a unix socket (#4807), which is machinery a service living inside the visor does not need.

`dmsg_web.secret_key` now runs the resolver under that key with neither. The visor builds a second client for it and attaches it to its **own** relay over an in-memory `net.Pipe`: one session, no socket, no discovery entry, and every stream carried by the visor's existing sessions and transports. The host pays for dmsg once.

`AttachInProcess` is the third pipe into the same `AcceptRelaySession` the skynet carrier and the unix socket already feed, and the cheapest — no hello preamble (a separate process needs one because it cannot know the acceptor's key before the Noise XK handshake; here the caller was handed the host client itself) and no listener, because the dial *is* the attach. It refuses a guest sharing the host's key, and the dialer refuses any carrier but skynet and any address but the host's own.

**Why this is not what #4500/#4501 removed.** That client *registered* — it posted a discovery entry under a throwaway key and churned 660 identities in fourteen days. A guest here is `NoRegister` by construction: no entry to churn, and nothing dials it inbound except through its host. That also bounds what it suits — an outbound resolver, not a service that must be reachable on its own. The code says so, so the next reader can check the difference before deleting it for the same reason.

## Verified on a live visor

With a configured key, both deployment services answer through the resolver under the second identity:

```
$ curl --socks5-hostname 127.0.0.1:4445 http://02b307ae….dmsg/health
{"service_name":"transport-discovery",…}
$ curl --socks5-hostname 127.0.0.1:4445 http://03234b2e….dmsg/health
{"service_name":"address-resolver",…}
```

and the host's session list is unchanged — six sessions, exactly what the visor already had, no second client's worth of dmsg load.

## Known limits, found while testing

A guest has no discovery of its own, so it depends entirely on the relay path — which means it inherits the relay's constraints, and two are worth naming because they cost me three bad test targets before I picked a valid one:

- A destination reachable from the host only over the **skynet** carrier cannot be forwarded to, because `relayForwardSessions` refuses to chain relay→relay. The host's own relay peer is exactly such a destination.
- A dmsg **server** destination takes the resolver's `isDirectServer` self-rendezvous path through the visor's direct client, not the guest's, so it is unaffected by this change either way.

Neither is new or introduced here, but a guest feels them harder than a normal client does, because it has no server sessions to fall back on.

`go build .`, `go vet`, and `go test` on `pkg/dmsg/dmsg`, `pkg/visor` and `pkg/visor/visorconfig` all pass. Stacks cleanly alongside #4807 — they share `AcceptRelaySession` but touch different files.