### PR TITLE
fix(dmsg-disc): a folded visor's client entry must not inherit the server TTL

### DIFF
--- a/pkg/dmsg/discovery/store/entry_stale_test.go
+++ b/pkg/dmsg/discovery/store/entry_stale_test.go
@@ -71,3 +71,19 @@ func TestServerEntryStaleAcceptsBothTimestampUnits(t *testing.T) {
 		require.False(t, serverEntryIsStale(srv(secondsTimestampCeiling-1), now))
 	})
 }
+
+// Folding a dmsg server into its visor puts both halves on ONE Redis key, so
+// the server's short TTL silently became the visor's CLIENT registration TTL
+// too — sixty minutes down to two. This pins the rule that only a server-ONLY
+// entry takes the short expiry.
+func TestDualEntryKeepsTheClientTTL(t *testing.T) {
+	short := func(e *disc.Entry) bool { return e.Server != nil && e.Client == nil }
+
+	require.True(t, short(&disc.Entry{Server: &disc.Server{}}),
+		"a server-only entry must expire on the server cadence")
+	require.False(t, short(&disc.Entry{Client: &disc.Client{}}),
+		"a client-only entry keeps the client TTL")
+	require.False(t, short(&disc.Entry{Client: &disc.Client{}, Server: &disc.Server{}}),
+		"a dual entry must keep the CLIENT TTL: its server half is retired by "+
+			"serverEntryIsStale, not by the key expiring under its client half")
+}

--- a/pkg/dmsg/discovery/store/redis.go
+++ b/pkg/dmsg/discovery/store/redis.go
@@ -145,10 +145,28 @@ func (r *redisStore) SetEntry(ctx context.Context, entry *disc.Entry, timeout ti
 		return disc.ErrUnexpected
 	}
 
-	if entry.Server != nil {
+	// A server-ONLY entry expires fast: a dmsg server re-registers every
+	// update interval, so two of them is generous, and letting a dead one
+	// linger is how clients end up dialing a delegated server that is gone.
+	//
+	// A DUAL entry — one key carrying both halves, which is what folding a
+	// dmsg server into its visor produces (#4787) — must NOT take that TTL.
+	// It is the same Redis key, so the two-minute expiry applied to the
+	// visor's CLIENT registration too, dropping it from sixty minutes to
+	// two: a thirtyfold cut in how long that visor tolerates a gap in its
+	// own re-registration. Any hiccup longer than two minutes and it
+	// vanishes from discovery outright — not merely unavailable as a
+	// server, but unresolvable as a client, which is the harder failure and
+	// the one its peers feel.
+	//
+	// The short TTL is no longer what retires a dead server anyway. #4797
+	// judges server liveness from the registration timestamp and withdraws a
+	// stale one from the servers set whether or not its key still exists. So
+	// a dual entry keeping the client TTL loses nothing: its server half is
+	// still withdrawn promptly, and its client half survives a hiccup.
+	if entry.Server != nil && entry.Client == nil {
 		timeout = dmsg.DefaultUpdateInterval * 2
 	}
-
 	err = r.client.Set(ctx, entry.Static.Hex(), payload, timeout).Err()
 	if err != nil {
 		log.WithError(err).Errorf("Failed to set entry in redis")


### PR DESCRIPTION
`SetEntry` forced the short server expiry whenever an entry had a `Server` section:

```go
if entry.Server != nil { timeout = dmsg.DefaultUpdateInterval * 2 }
```

Since #4787 one key can carry **both** halves — which is exactly what folding a dmsg server into its visor produces — and it is the same Redis key, so that two-minute TTL was applied to the visor's **client** registration as well. Sixty minutes down to two: a thirtyfold cut in how long a folded visor tolerates a gap in its own re-registration.

Past two minutes it does not merely stop being offered as a server; it vanishes from discovery entirely and is unresolvable as a client. That is the harder failure — its peers cannot find it at all — and it is silent: the visor is up, its transports are registered, and nothing on it reports a problem. A visor in exactly that state today (`tp disc --pk=` shows its transports, `mdisc entry` returns 404) is what sent me looking.

The short TTL is no longer what retires a dead server. #4797 judges server liveness from the registration timestamp and withdraws a stale one from the servers set whether or not its key still exists, so a dual entry keeping the client TTL loses nothing: the server half is still withdrawn promptly, and the client half survives a hiccup. Server-only entries are unchanged.

Server-side only, so it takes effect with the dmsg-discovery deploy — no fleet rollout.

`go build .`, `go vet ./pkg/dmsg/discovery/...` clean; the store tests pass (the three redis-backed ones need a live redis and are environmental, as before).

**This is not on its own a fix for a visor that has stopped publishing altogether** — it removes the amplifier that turns a brief registration gap into disappearing from discovery, which is a different and much more common failure.