### PR TITLE
fix(dmsg): stop silently dropping direct_only and relay_max_streams

### DIFF
--- a/pkg/dmsg/dmsgc/spec/dropped_keys_test.go
+++ b/pkg/dmsg/dmsgc/spec/dropped_keys_test.go
@@ -1,0 +1,47 @@
+// Package spec pkg/dmsg/dmsgc/spec/dropped_keys_test.go c1-net-dmsg
+package spec
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// DmsgConfig's codec is hand-written, so a visor-wide field carrying a json
+// tag is NOT automatically (de)serialized — it has to be listed. direct_only
+// and relay_max_streams were not, and were silently dropped both ways.
+//
+// relay_max_streams is the bound on how many streams this visor relays for
+// others, i.e. the only configured limit on relay amplification. A knob that
+// reads back as unset no matter what the operator wrote is worse than no knob.
+func TestDmsgConfigKeepsVisorWideKeys(t *testing.T) {
+	const raw = `{"discovery":"http://dmsgd","sessions_count":2,` +
+		`"direct_only":true,"relay_max_streams":64,"lookup_cxo":true}`
+
+	var c DmsgConfig
+	require.NoError(t, json.Unmarshal([]byte(raw), &c))
+	require.True(t, c.DirectOnly, "direct_only must survive unmarshal")
+	require.Equal(t, 64, c.RelayMaxStreams, "relay_max_streams must survive unmarshal")
+	require.True(t, c.LookupCXO)
+
+	out, err := json.Marshal(c)
+	require.NoError(t, err)
+
+	var back DmsgConfig
+	require.NoError(t, json.Unmarshal(out, &back))
+	require.True(t, back.DirectOnly, "direct_only must survive a round trip")
+	require.Equal(t, 64, back.RelayMaxStreams, "relay_max_streams must survive a round trip")
+	require.True(t, back.LookupCXO)
+}
+
+// The zero values stay absent, so a config that never set them does not grow
+// the keys on rewrite.
+func TestDmsgConfigOmitsUnsetVisorWideKeys(t *testing.T) {
+	var c DmsgConfig
+	require.NoError(t, json.Unmarshal([]byte(`{"discovery":"http://dmsgd"}`), &c))
+	out, err := json.Marshal(c)
+	require.NoError(t, err)
+	require.NotContains(t, string(out), "direct_only")
+	require.NotContains(t, string(out), "relay_max_streams")
+}

--- a/pkg/dmsg/dmsgc/spec/spec_native.go
+++ b/pkg/dmsg/dmsgc/spec/spec_native.go
@@ -23,6 +23,16 @@ import (
 type deploymentWithServer struct {
 	Deployment
 	Server *DmsgServerConfig `json:"server,omitempty"`
+	// DirectOnly and RelayMaxStreams are visor-wide too, and were MISSING
+	// here: both carry a json tag on DmsgConfig but the codec never read or
+	// wrote them, so every value an operator set was silently dropped on the
+	// way in and never written back out. relay_max_streams is the documented
+	// bound on how many streams this visor will relay for others — the only
+	// knob against relay amplification — so "unsettable" is the wrong default
+	// for it to have had. Defaults are unchanged; this only makes a value the
+	// operator actually wrote take effect.
+	DirectOnly      bool `json:"direct_only,omitempty"`
+	RelayMaxStreams int  `json:"relay_max_streams,omitempty"`
 	// LookupCXO is a visor-wide flag carried alongside the primary
 	// deployment in the single-object shape (like Server). See
 	// DmsgConfig.LookupCXO.
@@ -46,6 +56,8 @@ func (c *DmsgConfig) UnmarshalJSON(data []byte) error {
 		c.Deployments = []Deployment{single.Deployment}
 		c.Server = single.Server
 		c.LookupCXO = single.LookupCXO
+		c.DirectOnly = single.DirectOnly
+		c.RelayMaxStreams = single.RelayMaxStreams
 	}
 	c.mirrorPrimary()
 	return nil
@@ -63,7 +75,7 @@ func (c DmsgConfig) MarshalJSON() ([]byte, error) {
 		deployments = []Deployment{c.toDeployment()}
 	}
 	if len(deployments) == 1 {
-		return json.Marshal(deploymentWithServer{Deployment: deployments[0], Server: c.Server, LookupCXO: c.LookupCXO})
+		return json.Marshal(deploymentWithServer{Deployment: deployments[0], Server: c.Server, LookupCXO: c.LookupCXO, DirectOnly: c.DirectOnly, RelayMaxStreams: c.RelayMaxStreams})
 	}
 	return json.Marshal(deployments)
 }


### PR DESCRIPTION
`DmsgConfig`'s codec is hand-written — the array/object duality means `encoding/json` cannot do it — so a visor-wide field carrying a json tag is not serialized unless it is listed in `deploymentWithServer`. `Server` and `LookupCXO` are; `DirectOnly` and `RelayMaxStreams` never were.

Both were dropped in **both** directions: an operator's value never reached the client, and was erased from the config on the next rewrite.

`relay_max_streams` is the bound on how many streams a visor will relay for other peers — the only configured limit on relay amplification, and the one `DefaultClientMaxRelayedStreams` explicitly points operators at:

> *"Any visor with transports can be nominated as a relay by a peer … Bound it per visor with `dmsg.relay_max_streams`."*

It has been unsettable since it was added, on every visor. That matters more now than it did, because the default was recently raised from 256 to a full dmsg server's cap on the reasoning that visors attach to hubs as relays — so the ceiling went up while the only way to lower it was inert.

Defaults are unchanged: this only makes a value the operator actually wrote take effect, and the zero values stay `omitempty`, so a config that never set them does not grow the keys on rewrite.

Found while auditing the dmsg-over-skynet integration. `go build .`, `go vet`, `go test ./pkg/dmsg/dmsgc/...` pass; the new tests cover the round trip and the omitempty behaviour.