### PR TITLE
fix(dmsg): give each attached peer a share of the relay budget

### DIFF
--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -184,6 +184,8 @@ type EntityCommon struct {
 	// bridging on the same server is not counted. Set on Server entities.
 	maxRelayedStreams int
 	relayedStreams    int64
+	relayShare        map[cipher.PubKey]int64
+	relayShareMx      sync.Mutex
 
 	// acceptRelayedRequests admits a stream request over a CLIENT session
 	// whose SrcAddr.PK is not the session's remote key (see
@@ -436,25 +438,84 @@ func (c *EntityCommon) peerAnnounceAllowed(remotePK cipher.PubKey) bool {
 	return c.peerAnnounceAllowedFunc(remotePK)
 }
 
-// tryAcquireRelaySlot reserves capacity for one peer-relayed stream,
-// reporting false when the server is already at maxRelayedStreams. A
-// zero/unset cap means relaying is not configured (client entities) —
-// reject rather than relay unbounded. Pair every true return with a
-// releaseRelaySlot.
-func (c *EntityCommon) tryAcquireRelaySlot() bool {
+// relayPeerShareDivisor bounds how much of the global relay budget any ONE
+// attached peer may hold: maxRelayedStreams / this. The global cap alone is
+// not a fair share — it is a single counter, so the first peer to open 4096
+// streams starves every other peer on the hub, and the victims see refused
+// streams that look like unreachable services rather than a busy relay.
+//
+// A hub is exactly where that matters. Visors attach to a visor co-resident
+// with a dmsg server precisely because it is well connected, so the peers
+// sharing one budget are many and mutually unaware. libp2p's circuit relay
+// pairs its global reservation cap with a per-peer circuit cap for this
+// reason; a global-only cap was one of the things that made v1 relays "an
+// expensive proposition requiring dedicated hosts".
+//
+// Four is deliberately generous: it bounds the blast radius to a quarter
+// rather than partitioning the budget evenly across an unknown peer count,
+// which would starve a legitimate heavy user to protect against a
+// hypothetical one. An operator who wants a tighter share lowers
+// dmsg.relay_max_streams, which now takes effect (it was silently dropped by
+// the config codec until #4811).
+const relayPeerShareDivisor = 4
+
+// maxRelayedStreamsPerPeer is the per-peer ceiling, never below one: a cap so
+// small that the share rounds to zero would refuse every relayed stream and
+// read as a broken relay rather than a strict one.
+func (c *EntityCommon) maxRelayedStreamsPerPeer() int64 {
+	share := int64(c.maxRelayedStreams) / relayPeerShareDivisor
+	if share < 1 {
+		return 1
+	}
+	return share
+}
+
+// tryAcquireRelaySlot reserves capacity for one peer-relayed stream on behalf
+// of peer, reporting false when either the global budget or that peer's share
+// of it is exhausted. A zero/unset cap means relaying is not configured
+// (client entities) — reject rather than relay unbounded. Pair every true
+// return with a releaseRelaySlot for the same peer.
+func (c *EntityCommon) tryAcquireRelaySlot(peer cipher.PubKey) bool {
 	if c.maxRelayedStreams <= 0 {
 		return false
 	}
+	perPeer := c.maxRelayedStreamsPerPeer()
+
+	c.relayShareMx.Lock()
+	if c.relayShare == nil {
+		c.relayShare = make(map[cipher.PubKey]int64)
+	}
+	if c.relayShare[peer] >= perPeer {
+		c.relayShareMx.Unlock()
+		return false
+	}
+	c.relayShare[peer]++
+	c.relayShareMx.Unlock()
+
 	if atomic.AddInt64(&c.relayedStreams, 1) > int64(c.maxRelayedStreams) {
 		atomic.AddInt64(&c.relayedStreams, -1)
+		c.releasePeerShare(peer)
 		return false
 	}
 	return true
 }
 
 // releaseRelaySlot returns a slot reserved by tryAcquireRelaySlot.
-func (c *EntityCommon) releaseRelaySlot() {
+func (c *EntityCommon) releaseRelaySlot(peer cipher.PubKey) {
 	atomic.AddInt64(&c.relayedStreams, -1)
+	c.releasePeerShare(peer)
+}
+
+// releasePeerShare drops one of peer's held slots, deleting the entry at zero
+// so the map tracks live relaying rather than every peer ever seen.
+func (c *EntityCommon) releasePeerShare(peer cipher.PubKey) {
+	c.relayShareMx.Lock()
+	defer c.relayShareMx.Unlock()
+	if n := c.relayShare[peer]; n > 1 {
+		c.relayShare[peer] = n - 1
+	} else {
+		delete(c.relayShare, peer)
+	}
 }
 
 // promoteToPeer files an announced inbound session in the server's peer

--- a/pkg/dmsg/dmsg/relay_cap_test.go
+++ b/pkg/dmsg/dmsg/relay_cap_test.go
@@ -5,29 +5,39 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
 )
 
 // TestRelaySlotCap covers the always-on relay's stream-capacity bound:
 // tryAcquireRelaySlot admits up to maxRelayedStreams concurrent slots and
 // refuses beyond that, releaseRelaySlot frees a slot for reuse, and an
 // unconfigured cap (client entities) refuses to relay at all.
+//
+// Each acquire uses a DISTINCT peer, because the global budget is also shared
+// per-peer now (relayPeerShareDivisor): one peer filling the whole cap is the
+// starvation this test would otherwise be asserting is fine. The per-peer
+// half is covered in relay_share_test.go.
 func TestRelaySlotCap(t *testing.T) {
+	peer := func() cipher.PubKey { pk, _ := cipher.GenerateKeyPair(); return pk }
+
 	// Unconfigured cap: never relay.
 	var client EntityCommon
-	require.False(t, client.tryAcquireRelaySlot(), "unset cap must not relay")
+	require.False(t, client.tryAcquireRelaySlot(peer()), "unset cap must not relay")
 
 	c := EntityCommon{maxRelayedStreams: 3}
 
-	// Fill to capacity.
-	require.True(t, c.tryAcquireRelaySlot())
-	require.True(t, c.tryAcquireRelaySlot())
-	require.True(t, c.tryAcquireRelaySlot())
-	require.False(t, c.tryAcquireRelaySlot(), "at capacity, further acquires fail")
+	// Fill to capacity, one slot per peer.
+	require.True(t, c.tryAcquireRelaySlot(peer()))
+	require.True(t, c.tryAcquireRelaySlot(peer()))
+	last := peer()
+	require.True(t, c.tryAcquireRelaySlot(last))
+	require.False(t, c.tryAcquireRelaySlot(peer()), "at capacity, further acquires fail")
 
 	// Releasing one slot admits exactly one more.
-	c.releaseRelaySlot()
-	require.True(t, c.tryAcquireRelaySlot(), "a freed slot is reusable")
-	require.False(t, c.tryAcquireRelaySlot(), "back at capacity")
+	c.releaseRelaySlot(last)
+	require.True(t, c.tryAcquireRelaySlot(peer()), "a freed slot is reusable")
+	require.False(t, c.tryAcquireRelaySlot(peer()), "back at capacity")
 
 	// The live count never overshoots the cap under concurrency.
 	c2 := EntityCommon{maxRelayedStreams: 8}
@@ -38,7 +48,7 @@ func TestRelaySlotCap(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if c2.tryAcquireRelaySlot() {
+			if c2.tryAcquireRelaySlot(peer()) {
 				mu.Lock()
 				granted++
 				mu.Unlock()

--- a/pkg/dmsg/dmsg/relay_share_test.go
+++ b/pkg/dmsg/dmsg/relay_share_test.go
@@ -1,0 +1,70 @@
+// Package dmsg pkg/dmsg/dmsg/relay_share_test.go c1-net-dmsg
+package dmsg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// The global relay budget is one counter, so without a per-peer share the
+// first peer to open every slot starves every other peer on the hub — and the
+// victims see refused streams that look like unreachable services rather than
+// a busy relay.
+func TestRelaySlotPerPeerShare(t *testing.T) {
+	c := &EntityCommon{maxRelayedStreams: 8} // share = 8/4 = 2
+	a, _ := cipher.GenerateKeyPair()
+	b, _ := cipher.GenerateKeyPair()
+
+	require.True(t, c.tryAcquireRelaySlot(a))
+	require.True(t, c.tryAcquireRelaySlot(a))
+	require.False(t, c.tryAcquireRelaySlot(a), "a peer must not exceed its share")
+
+	// The budget is NOT exhausted — a starves only itself.
+	require.True(t, c.tryAcquireRelaySlot(b), "another peer still gets its share")
+	require.True(t, c.tryAcquireRelaySlot(b))
+	require.False(t, c.tryAcquireRelaySlot(b))
+
+	require.Equal(t, int64(4), c.relayedStreams, "four live streams across two peers")
+
+	// Releasing frees the share again.
+	c.releaseRelaySlot(a)
+	require.True(t, c.tryAcquireRelaySlot(a))
+}
+
+// The map tracks LIVE relaying, not every peer ever seen, or a long-running
+// hub accumulates an entry per peer forever.
+func TestRelayShareForgetsIdlePeers(t *testing.T) {
+	c := &EntityCommon{maxRelayedStreams: 8}
+	pk, _ := cipher.GenerateKeyPair()
+
+	require.True(t, c.tryAcquireRelaySlot(pk))
+	require.True(t, c.tryAcquireRelaySlot(pk))
+	c.releaseRelaySlot(pk)
+	c.releaseRelaySlot(pk)
+
+	c.relayShareMx.Lock()
+	n := len(c.relayShare)
+	c.relayShareMx.Unlock()
+	require.Zero(t, n, "a peer holding no slots must leave no entry behind")
+	require.Zero(t, c.relayedStreams)
+}
+
+// A cap too small to divide must still relay something: a share that rounds
+// to zero would refuse every stream and read as a broken relay.
+func TestRelayShareNeverRoundsToZero(t *testing.T) {
+	c := &EntityCommon{maxRelayedStreams: 2}
+	pk, _ := cipher.GenerateKeyPair()
+	require.Equal(t, int64(1), c.maxRelayedStreamsPerPeer())
+	require.True(t, c.tryAcquireRelaySlot(pk))
+	require.False(t, c.tryAcquireRelaySlot(pk))
+}
+
+// Relaying unconfigured still refuses rather than relaying unbounded.
+func TestRelayShareUnconfiguredRefuses(t *testing.T) {
+	c := &EntityCommon{}
+	pk, _ := cipher.GenerateKeyPair()
+	require.False(t, c.tryAcquireRelaySlot(pk))
+}

--- a/pkg/dmsg/dmsg/server_session.go
+++ b/pkg/dmsg/dmsg/server_session.go
@@ -391,11 +391,11 @@ func (ss *ServerSession) bridgeStream(log logrus.FieldLogger, yStr io.ReadWriteC
 	// Bound the concurrent count so an always-open relay can't be amplified. A
 	// plain local client↔client bridge is normal operation and is never gated.
 	if ss.isPeer || dst.isPeer || ss.relayInbound || req.SrcAddr.PK != ss.rPK {
-		if !ss.entity.tryAcquireRelaySlot() {
+		if !ss.entity.tryAcquireRelaySlot(ss.rPK) {
 			ss.m.RecordStream(metrics.DeltaFailed)
 			return ErrRelayCapacityReached
 		}
-		defer ss.entity.releaseRelaySlot()
+		defer ss.entity.releaseRelaySlot(ss.rPK)
 	}
 
 	yStr2, resp, err := dst.forwardRequest(req)


### PR DESCRIPTION
`maxRelayedStreams` was one global counter, so the first peer to open every slot starved every other peer on the relay — and the victims saw refused streams, which read as unreachable services rather than a busy hub.

That matters most exactly where the relay is most useful. Visors attach to a visor co-resident with a dmsg server *because* it is well connected, so the peers sharing one budget are many and mutually unaware. The cap was recently raised from 256 to 4096 on the reasoning that a hub does a server's job — a bigger shared pot with no per-peer share makes the starvation cheaper to cause, not harder.

Each peer may now hold at most a quarter of the budget. Deliberately generous rather than an even split across an unknown peer count: the point is to bound the blast radius, not to starve a legitimate heavy user in order to protect against a hypothetical one. The share never rounds below one, so a small cap still relays rather than refusing everything and looking broken. The map tracks live relaying only — a peer holding no slots leaves no entry — so a long-running hub does not accumulate one per peer ever seen.

`TestRelaySlotCap` now acquires under distinct peers: it was encoding "one peer may fill the entire budget", which is precisely the behaviour this changes.

## Why

Found auditing the dmsg-over-skynet integration against prior art. libp2p's circuit relay pairs its global reservation cap with a per-peer circuit cap (16 by default), and the v2 spec's own rationale names a global-only bound among the reasons v1 relays became *"an expensive proposition requiring dedicated hosts with significant hardware and bandwidth costs"*. RFC 8656 §21.3.2 is the counter-example: TURN permits unbounded chaining and offers only logging, which is how the ecosystem got open relays.

This is the second half of a pair. #4811 fixed `dmsg.relay_max_streams` being silently dropped by the config codec — until that merged, the global cap could not even be lowered. So the state until tonight was a single global cap, raised to 4096, unsettable, with no per-peer share.

`go build .`, `go vet`, and `go test -race ./pkg/dmsg/dmsg/` all pass.