### PR TITLE
fix(dmsg): min_hops is a property of traffic, not of session carriers

### DIFF
--- a/pkg/app/appnet/carrier_dial_test.go
+++ b/pkg/app/appnet/carrier_dial_test.go
@@ -1,0 +1,51 @@
+// Package appnet pkg/app/appnet/carrier_dial_test.go c3-app-net
+package appnet
+
+import (
+	"context"
+	"github.com/skycoin/skywire/pkg/router"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCarrierDialContext(t *testing.T) {
+	require.False(t, IsCarrierDial(context.Background()), "an ordinary dial is not a carrier dial")
+	require.False(t, IsCarrierDial(nil), "a nil context must not panic") //nolint:staticcheck // SA1012: nil-safety is the assertion
+	require.True(t, IsCarrierDial(WithCarrierDial(context.Background())))
+
+	// The marker survives derivation, which is how it reaches the networker:
+	// the visor wraps the dial ctx and then applies a timeout to it.
+	ctx, cancel := context.WithCancel(WithCarrierDial(context.Background()))
+	defer cancel()
+	require.True(t, IsCarrierDial(ctx))
+}
+
+// min_hops is a property of TRAFFIC — it keeps an intermediate from learning
+// the true source and destination. A carrier dial's destination IS the peer
+// that will carry the session, which terminates it and therefore knows whose
+// it is, so hops hide nothing from the only party positioned to learn
+// anything. What they cost is the bootstrap: an ineligible carrier dial falls
+// through to route setup, reached over the dmsg it is replacing.
+//
+// A per-dial value cannot express the exemption — EffectiveMinHops takes the
+// MAX of the global floor and any per-dial number, so a lower one is ignored.
+// This pins that the carrier flag bypasses the test outright, and that it does
+// NOT override an explicit per-dial mux request.
+func TestCarrierDialExemptFromMinHops(t *testing.T) {
+	// stubRouter reports 1; wrap it so this one reports a privacy-configured 3.
+	r := &SkywireNetworker{r: minHopsThree{}}
+
+	require.False(t, r.directShortcutEligible(&router.DialOptions{}, false),
+		"min_hops=3 keeps an ordinary dial out of the 0-hop shortcut")
+	require.True(t, r.directShortcutEligible(&router.DialOptions{}, true),
+		"a carrier dial takes the shortcut despite min_hops=3")
+	require.False(t, r.directShortcutEligible(&router.DialOptions{MuxRoutes: 2}, true),
+		"an explicit per-dial mux still forms a route group, carrier or not")
+}
+
+// minHopsThree is stubRouter with the one answer this test cares about
+// changed: a visor configured for sender privacy.
+type minHopsThree struct{ stubRouter }
+
+func (minHopsThree) EffectiveMinHops(*router.DialOptions) uint16 { return 3 }

--- a/pkg/app/appnet/networker.go
+++ b/pkg/app/appnet/networker.go
@@ -54,6 +54,48 @@ func AppNameFromContext(ctx context.Context) string {
 	return v
 }
 
+// carrierDialCtxKey marks a dial as a SESSION-CARRIER dial: this visor
+// reaching a peer it chose to carry its own dmsg session (the skynet carrier
+// — see pkg/visor/init_dmsg_relay.go). SkywireNetworker reads it via
+// IsCarrierDial.
+type carrierDialCtxKey struct{}
+
+// WithCarrierDial marks ctx as a session-carrier dial, which exempts it from
+// the visor-global min_hops.
+//
+// min_hops exists so an intermediate cannot learn the true source and
+// destination of this visor's TRAFFIC — with enough hops it only ever sees
+// its neighbours. A carrier dial is not traffic. Its destination IS the peer
+// that will carry the session, chosen by this visor, and that peer terminates
+// the session and therefore knows exactly whose it is. Extra hops hide
+// nothing from the only party in a position to learn anything, so min_hops
+// buys no privacy on this dial.
+//
+// What it costs is the bootstrap. min_hops >= 2 makes the carrier dial
+// ineligible for the 0-hop AppDirectMux shortcut, so it falls through to
+// route setup — which reaches the route finder and the setup node over dmsg,
+// the very thing the carrier is replacing. hasDirectTransportTo deliberately
+// refuses a multi-hop route for exactly this reason, but it cannot see that
+// min_hops has already forced one: holding a direct transport does not make a
+// dial one hop when the config forbids one hop. So on a visor configured for
+// privacy, dmsg-over-skynet silently could not converge — and failed into the
+// circular path rather than cleanly.
+//
+// Traffic dials are untouched: this marks only the carrier, and only the
+// visor sets it.
+func WithCarrierDial(ctx context.Context) context.Context {
+	return context.WithValue(ctx, carrierDialCtxKey{}, true)
+}
+
+// IsCarrierDial reports whether ctx was marked by WithCarrierDial.
+func IsCarrierDial(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	v, _ := ctx.Value(carrierDialCtxKey{}).(bool)
+	return v
+}
+
 // AddNetworker associates Networker with the `network`.
 func AddNetworker(t Type, n Networker) error {
 	networkersMx.Lock()

--- a/pkg/app/appnet/skywire_networker.go
+++ b/pkg/app/appnet/skywire_networker.go
@@ -138,7 +138,7 @@ func (r *SkywireNetworker) DialContextWithOptions(ctx context.Context, addr Addr
 	// "inherit Config.MinHops", so testing opts alone let a VPN client
 	// configured for min_hops=3 take this shortcut and get a single direct
 	// hop — the constraint bypassed before route setup was ever reached.
-	if r.directShortcutEligible(opts) {
+	if r.directShortcutEligible(opts, IsCarrierDial(ctx)) {
 		if directConn, ok := r.tryDirectDial(addr, opts.AppName); ok {
 			return &SkywireConn{
 				Conn:     directConn,
@@ -170,8 +170,19 @@ func (r *SkywireNetworker) DialContextWithOptions(ctx context.Context, addr Addr
 //     one", so mux_routes=1 no longer silently collapses to a 0-hop direct
 //     conn and never forming a route group. mux >= 2 already skipped the
 //     shortcut; this extends the same treatment to an explicit single route.
-func (r *SkywireNetworker) directShortcutEligible(opts *router.DialOptions) bool {
-	return r.r.EffectiveMinHops(opts) <= 1 && opts.MuxRoutes == 0
+func (r *SkywireNetworker) directShortcutEligible(opts *router.DialOptions, carrier bool) bool {
+	if opts.MuxRoutes != 0 {
+		return false
+	}
+	// A session-carrier dial skips the min-hops test entirely — not by
+	// passing a lower per-dial value, which cannot work: EffectiveMinHops
+	// takes the MAX of the visor-global floor and any per-dial value, so a
+	// per-dial number can only ever raise it. See appnet.WithCarrierDial for
+	// why min_hops buys no privacy on this dial and costs the bootstrap.
+	if carrier {
+		return true
+	}
+	return r.r.EffectiveMinHops(opts) <= 1
 }
 
 // DialPacketContext implements PacketNetworker — it opens a faithful-UDP

--- a/pkg/app/appnet/skywire_networker_router_test.go
+++ b/pkg/app/appnet/skywire_networker_router_test.go
@@ -116,7 +116,7 @@ func TestSkywireNetworker_DirectShortcutEligible(t *testing.T) {
 		{4, false},
 	}
 	for _, c := range cases {
-		got := r.directShortcutEligible(&router.DialOptions{MuxRoutes: c.mux})
+		got := r.directShortcutEligible(&router.DialOptions{MuxRoutes: c.mux}, false)
 		if got != c.want {
 			t.Errorf("directShortcutEligible(MuxRoutes=%d) = %v, want %v", c.mux, got, c.want)
 		}

--- a/pkg/dmsg/dmsg/client_relay.go
+++ b/pkg/dmsg/dmsg/client_relay.go
@@ -540,3 +540,11 @@ func (ce *Client) hasServerSession() bool {
 	}
 	return false
 }
+
+// RelayRefused reports how many stream requests this client has turned away
+// with ErrRelayCapacityReached since start — either the global budget or one
+// peer's share of it was full. Surfaced in `visor state` so a hub at its cap
+// is diagnosable from the hub rather than inferred from the peers it refused.
+func (ce *Client) RelayRefused() int {
+	return int(atomic.LoadInt64(&ce.relayRefused))
+}

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -186,6 +186,13 @@ type EntityCommon struct {
 	relayedStreams    int64
 	relayShare        map[cipher.PubKey]int64
 	relayShareMx      sync.Mutex
+	// relayRefused counts stream requests this entity turned away with
+	// ErrRelayCapacityReached (308). An overload error with no counter is an
+	// overload you first hear about from a user reporting an unreachable
+	// service: the refusal is indistinguishable, at the dialer, from the
+	// destination being down. libp2p's relay service exports rejections by
+	// reason for the same purpose.
+	relayRefused int64
 
 	// acceptRelayedRequests admits a stream request over a CLIENT session
 	// whose SrcAddr.PK is not the session's remote key (see

--- a/pkg/dmsg/dmsg/server_session.go
+++ b/pkg/dmsg/dmsg/server_session.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sync/atomic"
 	"time"
 
 	"github.com/0magnet/yamux"
@@ -393,6 +394,7 @@ func (ss *ServerSession) bridgeStream(log logrus.FieldLogger, yStr io.ReadWriteC
 	if ss.isPeer || dst.isPeer || ss.relayInbound || req.SrcAddr.PK != ss.rPK {
 		if !ss.entity.tryAcquireRelaySlot(ss.rPK) {
 			ss.m.RecordStream(metrics.DeltaFailed)
+			atomic.AddInt64(&ss.entity.relayRefused, 1)
 			return ErrRelayCapacityReached
 		}
 		defer ss.entity.releaseRelaySlot(ss.rPK)

--- a/pkg/visor/api_state_roles.go
+++ b/pkg/visor/api_state_roles.go
@@ -94,6 +94,12 @@ type DmsgRelayRole struct {
 	// A cap of 0 or less means this visor relays for nobody.
 	RelayedStreams    int `json:"relayed_streams"`
 	MaxRelayedStreams int `json:"max_relayed_streams"`
+	// RelayRefused counts stream requests turned away at capacity (dmsg error
+	// 308) since start. Nonzero means this hub refused traffic it was asked to
+	// carry — at the dialer that refusal is indistinguishable from the
+	// destination being down, so without this it is only ever diagnosed from
+	// the wrong end.
+	RelayRefused int `json:"relay_refused"`
 }
 
 // DmsgRelayAttachment is one nominated relay this visor holds a session with.
@@ -150,6 +156,7 @@ func (v *Visor) RolesSnapshot() *RolesSnapshot {
 		v.dmsgC.RelaySessionStreams(),
 		v.dmsgC.RelayedStreams(),
 		v.dmsgC.MaxRelayedStreams(),
+		v.dmsgC.RelayRefused(),
 	)
 	return r
 }
@@ -210,13 +217,14 @@ const (
 // clientStreams the per-peer stream count of the peers attached to this visor,
 // and relayed/max the slot usage against the configured cap.
 func dmsgRelayRole(port uint16, nominees []cipher.PubKey, sessions []dmsgSessionView,
-	clientStreams map[cipher.PubKey]int, relayed, maxStreams int) DmsgRelayRole {
+	clientStreams map[cipher.PubKey]int, relayed, maxStreams, refused int) DmsgRelayRole {
 
 	role := DmsgRelayRole{
 		Port:              port,
 		RelayPeers:        sortedPKs(nominees),
 		RelayedStreams:    relayed,
 		MaxRelayedStreams: maxStreams,
+		RelayRefused:      refused,
 	}
 
 	nominated := make(map[cipher.PubKey]struct{}, len(nominees))

--- a/pkg/visor/api_state_roles_test.go
+++ b/pkg/visor/api_state_roles_test.go
@@ -136,7 +136,7 @@ func TestDmsgServerRole_NoTransitAndPK(t *testing.T) {
 // A visor that nominates nobody and relays for nobody reports empty lists and
 // the cap it would enforce if anyone attached.
 func TestDmsgRelayRole_Idle(t *testing.T) {
-	role := dmsgRelayRole(skyenv.DmsgRelayPort, nil, nil, nil, 0, 4096)
+	role := dmsgRelayRole(skyenv.DmsgRelayPort, nil, nil, nil, 0, 4096, 0)
 
 	require.Equal(t, skyenv.DmsgRelayPort, role.Port)
 	require.Empty(t, role.RelayPeers)
@@ -144,6 +144,7 @@ func TestDmsgRelayRole_Idle(t *testing.T) {
 	require.Empty(t, role.RelayClients)
 	require.Zero(t, role.RelayedStreams)
 	require.Equal(t, 4096, role.MaxRelayedStreams)
+	require.Zero(t, role.RelayRefused, "an idle hub has refused nothing")
 }
 
 // Nominees are reported whether or not they were reached; only the ones with a
@@ -158,7 +159,7 @@ func TestDmsgRelayRole_AttachedNominees(t *testing.T) {
 		[]dmsgSessionView{
 			{PK: hub, Carrier: "skynet", Streams: 3, LatencyMS: 42},
 			{PK: server, Carrier: "tcp", Streams: 9}, // a plain server, not a nominee
-		}, nil, 0, 4096)
+		}, nil, 0, 4096, 0)
 
 	require.Len(t, role.RelayPeers, 2, "both nominees are reported")
 	require.Len(t, role.Attached, 1, "only the nominee with a session is attached")
@@ -178,11 +179,12 @@ func TestDmsgRelayRole_RelayingForPeers(t *testing.T) {
 	b, _ := cipher.GenerateKeyPair()
 
 	role := dmsgRelayRole(skyenv.DmsgRelayPort, nil, nil,
-		map[cipher.PubKey]int{a: 2, b: 5}, 7, 4096)
+		map[cipher.PubKey]int{a: 2, b: 5}, 7, 4096, 3)
 
 	require.Len(t, role.RelayClients, 2)
 	require.Equal(t, 7, role.RelayedStreams)
 	require.Equal(t, 4096, role.MaxRelayedStreams)
+	require.Equal(t, 3, role.RelayRefused, "refusals are reported from the hub that made them")
 
 	streams := map[cipher.PubKey]int{}
 	for _, c := range role.RelayClients {
@@ -199,7 +201,7 @@ func TestDmsgRelayRole_RelayingForPeers(t *testing.T) {
 // A negative cap is the "never relay for anyone" setting, and stays visible as
 // such rather than being normalized away.
 func TestDmsgRelayRole_RefusesToRelay(t *testing.T) {
-	role := dmsgRelayRole(skyenv.DmsgRelayPort, nil, nil, nil, 0, -1)
+	role := dmsgRelayRole(skyenv.DmsgRelayPort, nil, nil, nil, 0, -1, 0)
 	require.Equal(t, -1, role.MaxRelayedStreams)
 	require.Empty(t, role.RelayClients)
 }

--- a/pkg/visor/init_dmsg_relay.go
+++ b/pkg/visor/init_dmsg_relay.go
@@ -47,7 +47,11 @@ func skynetSessionDialer(ctx context.Context, network, addr string) (net.Conn, e
 	if err != nil {
 		return nil, err
 	}
-	dialCtx, cancel := context.WithTimeout(ctx, skynetSessionDialTimeout)
+	// Mark this as a carrier dial: min_hops must not apply to it (see
+	// appnet.WithCarrierDial), or a visor configured for privacy cannot
+	// converge onto skynet and fails into route setup over the dmsg it is
+	// replacing.
+	dialCtx, cancel := context.WithTimeout(appnet.WithCarrierDial(ctx), skynetSessionDialTimeout)
 	defer cancel()
 	return appnet.DialContext(dialCtx, appnet.Addr{
 		Net:    appnet.TypeSkynet,


### PR DESCRIPTION
`min_hops` keeps an intermediate from learning the true source and destination of this visor's **traffic**. A session-carrier dial is not traffic: its destination *is* the peer that will carry the session, chosen by this visor, and that peer terminates the session and therefore knows exactly whose it is. Extra hops hide nothing from the only party positioned to learn anything.

What they cost is the bootstrap. `min_hops >= 2` made the carrier dial ineligible for the 0-hop AppDirectMux shortcut, so it fell through to route setup — reached through the route finder and the setup node **over dmsg**, the very thing the carrier is replacing. `hasDirectTransportTo` refuses a multi-hop route for exactly that reason, but it cannot see that `min_hops` has already forced one: holding a direct transport does not make a dial one hop when the config forbids one hop. So on a visor configured for privacy, dmsg-over-skynet could not converge — and failed into the circular path rather than cleanly.

The exemption cannot be expressed as a per-dial value. `EffectiveMinHops` takes the **max** of the global floor and any per-dial number, so a lower one is ignored (I tried that first; it was a no-op). It is a context marker — `appnet.WithCarrierDial`, following the existing `WithAppName` pattern — that the shortcut test honors, set only by the visor and only on the skynet session dial. Traffic dials are untouched, and an explicit per-dial `--mux` still forms a route group, carrier or not.

## Also: count the 308s

`ErrRelayCapacityReached` had no counter. At the dialer a refusal is indistinguishable from the destination being down, so a hub at its cap was only ever diagnosed from the wrong end — by whoever it refused. `RelayRefused` now appears in `visor state` beside the slot counts, which is what libp2p's relay service exports rejections-by-reason for.

Both found auditing the dmsg-over-skynet integration; the per-peer share half is #4812.

`go build .`, `go vet`, and `go test` on `pkg/app/appnet`, `pkg/dmsg/dmsg`, `pkg/visor` all pass. New tests pin the exemption (including that it does not override an explicit mux) and the refusal reporting.