### PR TITLE
fix(cli): --jq and --shape were silently ignored by the discovery commands

### DIFF
--- a/cmd/skywire-cli/cliutil/cliutil.go
+++ b/cmd/skywire-cli/cliutil/cliutil.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
+	"github.com/bitfield/script"
 	"github.com/google/uuid"
 	"github.com/spf13/pflag"
 
@@ -191,4 +193,46 @@ func CheckDirectViaScheme(cmdFlags *pflag.FlagSet, value, want string) {
 				want, value))
 		}
 	}
+}
+
+// PrintPipe renders a bitfield/script pipeline through PrintOutput so the
+// global --json / --jq / --shape flags apply to it.
+//
+// Commands that build their output with a script pipeline used to end it in
+// .Stdout(), writing straight past the printer. The flags were then accepted
+// and silently ignored: `cli pv --jq length` printed the list of keys, and
+// --shape printed the list too. Nothing in --help distinguished those commands
+// from the ones that honor the contract, so the only way to find out was to
+// pipe the result somewhere and notice it was not JSON.
+//
+// The JSON form is the pipeline's non-empty output lines as an array of
+// strings, which is what a caller filtering a list command actually wants
+// (`--jq length` counts them). The human form is the text exactly as the
+// pipeline produced it, so default output is unchanged.
+func PrintPipe(cmdFlags *pflag.FlagSet, p *script.Pipe) {
+	out, err := p.String()
+	if err != nil {
+		PrintError(cmdFlags, err)
+		return
+	}
+	lines := []string{}
+	for _, l := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if strings.TrimSpace(l) != "" {
+			lines = append(lines, l)
+		}
+	}
+	PrintOutput(cmdFlags, lines, out)
+}
+
+// PrintRawJSON renders an already-serialized JSON document through PrintOutput
+// so --jq / --shape can address its real structure rather than its text.
+//
+// Used by the --raw branches of the discovery commands, which previously
+// colorized the document and wrote it straight to stdout.
+func PrintRawJSON(cmdFlags *pflag.FlagSet, raw, human string) {
+	if raw == "" {
+		PrintOutput(cmdFlags, nil, human)
+		return
+	}
+	PrintOutput(cmdFlags, json.RawMessage(raw), human)
 }

--- a/cmd/skywire-cli/commands/mdisc/root.go
+++ b/cmd/skywire-cli/commands/mdisc/root.go
@@ -168,7 +168,7 @@ selects the test deployment. Both apply to every subcommand.`,
 			internal.PrintOutput(cmd.Flags(), fmt.Sprintf("%d dmsg clients\n", stats), fmt.Sprintf("%d dmsg clients\n", stats))
 			return
 		}
-		script.Echo(dmsgclientkeys).JQ(".[]").Replace("\"", "").Freq().Column(2).Stdout() //nolint:errcheck,gosec
+		internal.PrintPipe(cmd.Flags(), script.Echo(dmsgclientkeys).JQ(".[]").Replace("\"", "").Freq().Column(2))
 	},
 }
 

--- a/cmd/skywire-cli/commands/pv/pv.go
+++ b/cmd/skywire-cli/commands/pv/pv.go
@@ -185,7 +185,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`, getDeployment(
 		// Fetch SD
 		sds := clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFile(cacheDirSD, sdFullURL), sdFullURL, cacheFilesAge)
 		if rawData {
-			script.Echo(string(pretty.Color(pretty.Pretty([]byte(sds)), nil))).Stdout() //nolint:errcheck,gosec
+			internal.PrintRawJSON(cmd.Flags(), sds, string(pretty.Color(pretty.Pretty([]byte(sds)), nil)))
 			return
 		}
 
@@ -214,7 +214,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`, getDeployment(
 					}{Count: count}, fmt.Sprintf("%v\n", count))
 					return
 				}
-				script.Echo(sds).JQ(sdJQ).Replace(`"`, "").Stdout() //nolint:errcheck,gosec
+				internal.PrintPipe(cmd.Flags(), script.Echo(sds).JQ(sdJQ).Replace(`"`, ""))
 				return
 			}
 
@@ -256,7 +256,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`, getDeployment(
 					}{Count: count}, fmt.Sprintf("%v\n", count))
 					return
 				}
-				script.Echo(joinedJSON).JQ(jqFilter).Replace(`"`, "").Stdout() //nolint:errcheck,gosec
+				internal.PrintPipe(cmd.Flags(), script.Echo(joinedJSON).JQ(jqFilter).Replace(`"`, ""))
 				return
 			}
 

--- a/cmd/skywire-cli/commands/tp/tp-visor.go
+++ b/cmd/skywire-cli/commands/tp/tp-visor.go
@@ -115,7 +115,7 @@ Set cache file location to "" to avoid using cache files`,
 		// --- Fetch SD ---
 		sds := clirpc.FetchCachedServiceURL(cmd.Flags(), vCacheFileSD, vSDURL+"/api/services?type="+visorServiceType, vCacheFilesAge)
 		if vRawData {
-			script.Echo(string(pretty.Color(pretty.Pretty([]byte(sds)), nil))).Stdout() //nolint:errcheck,gosec
+			internal.PrintRawJSON(cmd.Flags(), sds, string(pretty.Color(pretty.Pretty([]byte(sds)), nil)))
 			return
 		}
 
@@ -136,7 +136,7 @@ Set cache file location to "" to avoid using cache files`,
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("error: %w", err))
 			}
-			script.Echo(string(pretty.Color(pretty.Pretty(jsonOut), nil))).Stdout() //nolint:errcheck,gosec
+			internal.PrintRawJSON(cmd.Flags(), string(jsonOut), string(pretty.Color(pretty.Pretty(jsonOut), nil)))
 			return
 		}
 
@@ -174,10 +174,12 @@ Set cache file location to "" to avoid using cache files`,
 				if err != nil {
 					internal.PrintFatalError(cmd.Flags(), fmt.Errorf("error: %w", err))
 				}
-				script.Echo(fmt.Sprintf("%v\n", count)).Stdout() //nolint:errcheck,gosec
+				internal.PrintOutput(cmd.Flags(), struct {
+					Count int `json:"count"`
+				}{Count: count}, fmt.Sprintf("%v\n", count))
 				return
 			}
-			script.Echo(sds).JQ(sdJQ).Replace(`"`, "").Stdout() //nolint:errcheck,gosec
+			internal.PrintPipe(cmd.Flags(), script.Echo(sds).JQ(sdJQ).Replace(`"`, ""))
 			return
 		}
 
@@ -193,10 +195,12 @@ Set cache file location to "" to avoid using cache files`,
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("error: %w", err))
 			}
-			script.Echo(fmt.Sprintf("%v\n", count)).Stdout() //nolint:errcheck,gosec
+			internal.PrintOutput(cmd.Flags(), struct {
+				Count int `json:"count"`
+			}{Count: count}, fmt.Sprintf("%v\n", count))
 			return
 		}
 
-		script.Echo(joinedJSON).JQ(jqFilter).Replace(`"`, "").Stdout() //nolint:errcheck,gosec
+		internal.PrintPipe(cmd.Flags(), script.Echo(joinedJSON).JQ(jqFilter).Replace(`"`, ""))
 	},
 }

--- a/cmd/skywire-cli/commands/ut/root.go
+++ b/cmd/skywire-cli/commands/ut/root.go
@@ -380,10 +380,10 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`, getDeployment(
 		// Handle list-versions flag (without version filter)
 		if listVersions {
 			if isStats {
-				script.Echo(uts).JQ(baseSelector+" | .version").Freq().Replace("\"", "").Stdout() //nolint:errcheck,gosec
+				internal.PrintPipe(cmd.Flags(), script.Echo(uts).JQ(baseSelector+" | .version").Freq().Replace("\"", ""))
 				return
 			}
-			script.Echo(uts).JQ(baseSelector+" | \"\\(.pk) \\(.version)\"").Match(pk).Replace("\"", "").Stdout() //nolint:errcheck,gosec
+			internal.PrintPipe(cmd.Flags(), script.Echo(uts).JQ(baseSelector+" | \"\\(.pk) \\(.version)\"").Match(pk).Replace("\"", ""))
 			return
 		}
 
@@ -395,7 +395,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`, getDeployment(
 				return
 			}
 			if isMoreStats {
-				script.Echo(uts).JQ(".[] | select(.on) | .version").Freq().Replace("\"", "").Stdout() //nolint:errcheck,gosec
+				internal.PrintPipe(cmd.Flags(), script.Echo(uts).JQ(".[] | select(.on) | .version").Freq().Replace("\"", ""))
 				return
 			}
 			for _, i := range utKeysOnline {
@@ -410,7 +410,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`, getDeployment(
 			return
 		}
 		if isMoreStats {
-			script.Echo(uts).JQ(".[] | .version").Freq().Replace("\"", "").Stdout() //nolint:errcheck,gosec
+			internal.PrintPipe(cmd.Flags(), script.Echo(uts).JQ(".[] | .version").Freq().Replace("\"", ""))
 			return
 		}
 
@@ -418,6 +418,6 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`, getDeployment(
 		if dateFilter != "" {
 			dailyFilter = " | select(.key == \"" + dateFilter + "\")"
 		}
-		script.Echo(uts).JQ(".[] | \"\\(.pk) \\(.daily | to_entries[]"+dailyFilter+" | select(.value | tonumber > "+fmt.Sprintf("%d", minUT)+") | \"\\(.key) \\(.value)\")\"").Match(pk).Replace("\"", "").Stdout() //nolint:errcheck,gosec
+		internal.PrintPipe(cmd.Flags(), script.Echo(uts).JQ(".[] | \"\\(.pk) \\(.daily | to_entries[]"+dailyFilter+" | select(.value | tonumber > "+fmt.Sprintf("%d", minUT)+") | \"\\(.key) \\(.value)\")\"").Match(pk).Replace("\"", ""))
 	},
 }


### PR DESCRIPTION
`cli pv --jq length` printed the list of public keys. So did `--shape`. The flags are registered persistently on the root and documented as applying everywhere, but the commands that build their output with a bitfield/script pipeline ended it in `.Stdout()`, writing straight past the printer that reads them — and nothing in `--help` distinguished those commands from the ones that honor the contract.

Adds `cliutil.PrintPipe` (pipeline output through `PrintOutput`, JSON form being the non-empty lines) and `cliutil.PrintRawJSON` (an already-serialized document, so `--jq` addresses its real structure rather than its text), and routes `pv`, `tp v`, `ut` and `mdisc` through them.

Default human output is byte-identical on `pv`, `tp v` and `mdisc` against a build of develop. `cli pv --jq length` now returns 35, agreeing with `cli pv -s`.