### PR TITLE
fix(cxo): a stale tpd-stats leaf was served forever instead of resynced

### DIFF
--- a/pkg/visor/api_tpd_stats_subscriber.go
+++ b/pkg/visor/api_tpd_stats_subscriber.go
@@ -79,19 +79,28 @@ func (v *Visor) FetchTPDStatsCXO(kind string) ([]byte, time.Time, error) {
 	mgr.AcquireFor(TabNetworkStats)
 	defer mgr.ReleaseFor(TabNetworkStats)
 
-	if body, ts, ok := readStatsLeaf(mgr, path); ok {
+	// A leaf that is present AND fresh is served straight from the snapshot.
+	// Freshness is checked, not assumed: the cycle stops between calls, so a
+	// leaf can sit here aging indefinitely, and serving it unconditionally is
+	// what made this path disagree with the live endpoint it mirrors.
+	maxAge := statsMaxAge(kind)
+	if body, ts, ok := readStatsLeaf(mgr, path); ok && time.Since(ts) <= maxAge {
 		return body, ts, nil
 	}
-	// Cold snapshot: AcquireFor only started the cycle. Block briefly for the
-	// first sync (over dmsg) so CXO serves this call instead of the caller
+	// Cold or stale snapshot: AcquireFor only started the cycle. Block briefly
+	// for the sync (over dmsg) so CXO serves this call instead of the caller
 	// falling back to dmsg-http. These are sub-kilobyte leaves, so the short
 	// FirstSyncTimeout applies — no large-feed budget for this feed.
 	ctx, cancel := context.WithTimeout(context.Background(), feedFirstSyncTimeout(FeedTPDStats))
 	_, _ = mgr.RefreshNow(ctx, FeedTPDStats) //nolint:errcheck
 	cancel()
-	if body, ts, ok := readStatsLeaf(mgr, path); ok {
+	if body, ts, ok := readStatsLeaf(mgr, path); ok && time.Since(ts) <= maxAge {
 		return body, ts, nil
 	}
+	// Still stale after a resync: report a miss so the caller's chain falls
+	// through to the live service rather than being handed a number that is
+	// quietly wrong. A stale aggregate is worse than a slower correct one —
+	// nothing downstream can tell it apart from a current reading.
 	return nil, time.Time{}, ErrTPDStatsNotReady
 }
 
@@ -117,4 +126,27 @@ func readStatsLeaf(mgr statsSnapshot, path string) ([]byte, time.Time, bool) {
 	// Walk/Get lend the snapshot's bytes and Gunzip of a raw body returns
 	// that same slice, so copy before handing it to an RPC marshaller.
 	return append([]byte(nil), decoded...), ts, true
+}
+
+// statsMaxAge bounds how old a cached leaf may be before FetchTPDStatsCXO
+// treats it as stale and forces a resync.
+//
+// AcquireFor/ReleaseFor bracket a single call, so the refcount drops back to
+// zero the moment it returns and the cycle stops. The snapshot then sits in the
+// manager's map and ages. Because the old read path only called RefreshNow when
+// the leaf was ABSENT, a present-but-stale leaf was served forever: observed
+// live as `cli tp net-stats` reporting a total 34% above what TPD itself
+// returned, frozen at the same value for twenty minutes, while
+// `cli svc tpd stats` (which does not take the CXO step) tracked the network.
+// Two commands, one endpoint, two answers.
+//
+// The bounds follow the publisher's cadence
+// (pkg/deployment/tpd/api/cxo_stats_publisher.go): network and versions are
+// rewritten every ~12s, daily every ~5m. A few multiples of that is late enough
+// to be unambiguously a stopped cycle rather than a slow one.
+func statsMaxAge(kind string) time.Duration {
+	if kind == StatsKindDaily {
+		return 15 * time.Minute
+	}
+	return 90 * time.Second
 }

--- a/pkg/visor/api_tpd_stats_subscriber_test.go
+++ b/pkg/visor/api_tpd_stats_subscriber_test.go
@@ -135,3 +135,65 @@ func TestReadStatsLeafCopiesBody(t *testing.T) {
 		t.Fatalf("returned body aliases the snapshot: %q", body)
 	}
 }
+
+// TestStatsMaxAgeTracksPublisherCadence pins the staleness bounds to the
+// publisher's republish cadence: network and versions are rewritten every ~12s,
+// daily every ~5m, so the bound for the fast leaves must be far tighter than
+// for daily and both must leave room for a slow-but-live cycle.
+func TestStatsMaxAgeTracksPublisherCadence(t *testing.T) {
+	fast := statsMaxAge(StatsKindNetwork)
+	if got := statsMaxAge(StatsKindVersions); got != fast {
+		t.Fatalf("versions bound = %v, want the same as network (%v)", got, fast)
+	}
+	if fast <= 12*time.Second {
+		t.Fatalf("network bound %v leaves no room for a slow publish (cadence ~12s)", fast)
+	}
+	if fast >= 5*time.Minute {
+		t.Fatalf("network bound %v is too loose to catch a stopped cycle", fast)
+	}
+	daily := statsMaxAge(StatsKindDaily)
+	if daily <= 5*time.Minute {
+		t.Fatalf("daily bound %v is tighter than the ~5m publish cadence", daily)
+	}
+	if daily <= fast {
+		t.Fatalf("daily bound %v must exceed the fast-leaf bound %v", daily, fast)
+	}
+}
+
+// TestStatsFreshnessGate is the read-path decision FetchTPDStatsCXO makes
+// around readStatsLeaf: a present leaf is only servable while it is within the
+// bound for its kind. Before this gate existed a present-but-stale leaf was
+// returned unconditionally, which is how `cli tp net-stats` came to report a
+// total 34% above the live endpoint, frozen for twenty minutes.
+func TestStatsFreshnessGate(t *testing.T) {
+	raw, err := json.Marshal(tpdapi.NetworkStats{Total: 11551, UniqueVisors: 912})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	maxAge := statsMaxAge(StatsKindNetwork)
+
+	for _, tc := range []struct {
+		name     string
+		age      time.Duration
+		servable bool
+	}{
+		{"just published", 0, true},
+		{"within bound", maxAge - time.Second, true},
+		{"past bound", maxAge + time.Second, false},
+		{"cycle long stopped", 20 * time.Minute, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr := fakeStatsSnapshot{
+				bodies: map[string][]byte{tpdapi.StatsPathNetwork: cxoutils.Gzip(raw)},
+				at:     time.Now().Add(-tc.age),
+			}
+			_, ts, ok := readStatsLeaf(mgr, tpdapi.StatsPathNetwork)
+			if !ok {
+				t.Fatal("readStatsLeaf missed a present leaf")
+			}
+			if servable := time.Since(ts) <= maxAge; servable != tc.servable {
+				t.Fatalf("leaf aged %v servable = %v, want %v", tc.age, servable, tc.servable)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`cli tp net-stats` reported 15388 transports while TPD itself returned 11551, frozen on that number for twenty minutes, while `cli svc tpd stats` (which does not take the CXO step) tracked the network. Same endpoint, two answers.

`FetchTPDStatsCXO` brackets its read with `AcquireFor`/`ReleaseFor`, so the refcount falls to zero as soon as the call returns and the cycle stops; the snapshot then ages in place. `RefreshNow` was only reached when the leaf was **absent**, so once a leaf existed it was served unconditionally regardless of age — the function's own doc comment calls `lastRootAt` a liveness signal and then never reads it. Observed live via `cli visor cxo status`: `tpd-stats  refcount 0  cycle false`.

Gates the read on leaf age, resyncs a stale leaf, and reports a miss if it is still stale so the caller falls through to the live service. Bounds follow the publisher's cadence in `cxo_stats_publisher.go` (network/versions ~12s, daily ~5m). Two tests: one pinning the bounds to that cadence, one covering the servable/not-servable decision across four ages.