### PR TITLE
fix(dmsg): an attached client treated its own success as "nothing to connect to"

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -640,6 +640,33 @@ serve:
 			}
 		}
 		if len(entries) == 0 && len(relays) == 0 {
+			// Nothing to dial can mean two opposite things, and the loop used
+			// to assume the bad one. relayEntries() lists nominees that still
+			// NEED a session — it skips any nominee already connected — so an
+			// ATTACHED client's list goes empty at the exact moment its attach
+			// SUCCEEDS. With no servers in discovery either (an attached client
+			// carries an empty direct discovery by design), this read as
+			// "nothing to connect to" and warned + backed off, forever, while
+			// the relay session was up and carrying traffic. Observed live: a
+			// `dmsg web --attach` serving correctly logged "No entries found"
+			// eleven times in ten minutes.
+			//
+			// A satisfied client rests the same way it does when it DOES have
+			// entries (the select further down): block until a session drops,
+			// then re-enter and redial. That path is unreachable from here only
+			// because it sits inside the per-entry loop.
+			if ce.conf.MinSessions != 0 && ce.sessionsSatisfied() {
+				select {
+				case <-ce.done:
+					return
+				case err := <-ce.errCh:
+					ce.log.WithError(err).Debug("Session stopped.")
+					if isClosed(ce.done) {
+						return
+					}
+				}
+				continue
+			}
 			ce.log.Warnf("No entries found. Retrying after %s...", ce.bo.String())
 			if pinned {
 				ce.pinnedFailures.Add(1)

--- a/pkg/dmsg/dmsg/relay_local_test.go
+++ b/pkg/dmsg/dmsg/relay_local_test.go
@@ -5,9 +5,12 @@ import (
 	"context"
 	"net"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -191,4 +194,86 @@ func TestLocalRelaySessionDialerRejectsOtherCarriers(t *testing.T) {
 	_, err := d.SessionDialer()(context.Background(), CarrierTCP, "1.2.3.4:80")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unsupported carrier")
+}
+
+// TestAttachedClientRestsInsteadOfHuntingServers is the regression for the
+// serve loop treating a SUCCESSFUL attach as "nothing to connect to".
+//
+// relayEntries() lists nominees that still NEED a session, so an attached
+// client's list is empty precisely because its one nominee is connected; its
+// discovery is empty by design. The loop read both emptinesses together as a
+// failure and warned + backed off on a client that was up and serving. The
+// symptom in production was `dmsg web --attach` logging "No entries found"
+// every few seconds forever while it answered requests correctly.
+//
+// The assertion is behavioral rather than log-scraping: once ready, the client
+// must SETTLE — the same single relay session, still on the skynet carrier,
+// across several backoff intervals. A client stuck in the old path re-entered
+// discovery on every pass, so it could not be relied on to hold still.
+func TestAttachedClientRestsInsteadOfHuntingServers(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "relay.sock")
+	lis, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+
+	relay, _ := newLocalRelayTestClient(t, "rest-acceptor", false, DefaultClientMaxRelayedStreams)
+	defer relay.Close() //nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	go func() {
+		_ = relay.ServeLocalRelay(ctx, lis, 70, nil) //nolint:errcheck
+	}()
+
+	attached, _ := newLocalRelayTestClient(t, "rest-client", true, 0)
+	// A logger private to this client: the package-level logger is shared with
+	// every other client in the test binary, and redirecting IT races with their
+	// serve goroutines.
+	logs := &syncBuffer{}
+	lr := logrus.New()
+	lr.SetOutput(logs)
+	lr.SetLevel(logrus.DebugLevel)
+	attached.SetLogger(&logging.Logger{FieldLogger: lr})
+	defer attached.Close() //nolint:errcheck
+
+	_, err = attached.AttachLocalRelay(ctx, "unix", sock)
+	require.NoError(t, err)
+	go attached.Serve(ctx)
+
+	select {
+	case <-attached.Ready():
+	case <-ctx.Done():
+		t.Fatal("attached client never became ready")
+	}
+
+	// sessionsSatisfied is what the fixed guard consults; it must agree that a
+	// relay-only client holding its relay session wants nothing more.
+	require.True(t, attached.sessionsSatisfied(),
+		"a relay-only client on its relay must be satisfied, else the loop hunts for servers")
+
+	// The symptom itself: a satisfied attached client must stop re-entering
+	// discovery. Each pass through the old path emitted this warning and grew
+	// the backoff; the fixed path blocks until a session drops.
+	time.Sleep(1500 * time.Millisecond)
+	require.Zero(t, strings.Count(logs.String(), "No entries found"),
+		"a serving attached client must not report \"No entries found\"")
+	require.Len(t, attached.AllSessions(), 1, "still exactly one session")
+}
+
+// syncBuffer is a logrus output sink the test can read while the serve
+// goroutine is still writing to it.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }


### PR DESCRIPTION
A standalone client attached to a visor's relay (`dmsg web --attach`, `dmsg curl --attach`) logs `No entries found. Retrying after …` every few seconds forever while it is up and answering requests — eleven times in the ten minutes one ran here. Anyone reading that log would conclude the attach had failed.

`relayEntries()` lists nominees that still **need** a session and skips any already connected, so an attached client's list goes empty at the exact moment its attach **succeeds**. Its discovery is empty too, by design — an attached client carries an empty direct discovery because the relay does its own resolution. The serve loop read both emptinesses together as "nothing to connect to".

The loop already has the correct resting state for a satisfied client (block on `done`/`errCh` until a session drops, then redial); it was just unreachable from here, sitting inside the per-entry loop that an empty entry list never enters. A satisfied client now rests there instead of warning and backing off. `sessionsSatisfied()` is unchanged — it already answered this correctly, nothing consulted it in time.

Verified live before and after against a `dmsg web --attach` on this machine: it fetched TPD `/health` under a standalone key holding exactly one session and publishing no entry, while emitting the warning throughout. The regression test asserts the symptom a log reader sees and fails without the fix (`Should be zero, but was 1`); it gives the client its own logrus instance rather than redirecting the package logger, which races with other clients' serve goroutines in the same binary (caught by `-race`).