### PR TITLE
test(cxo): stop the bounded-retention tests failing on a loaded runner

### DIFF
--- a/pkg/cxo/treestore/leak_repro_test.go
+++ b/pkg/cxo/treestore/leak_repro_test.go
@@ -143,7 +143,34 @@ func TestPublisherAsyncCleanupBounded(t *testing.T) {
 	// One stable Root references ~10–12 small structural objects plus
 	// 2 large leaf TreeEntries. Total volume bound: ~6 MB. Anything
 	// larger means the per-tick leak returned.
-	if vol > 8*1024*1024 {
+	const limit = 8 * 1024 * 1024
+	if vol = awaitVolumeBound(t, cxds, limit, 30*time.Second); vol > limit {
 		t.Errorf("CXDS volume %d > 8 MB — async cleanup leak (per-Root retention should be ~6 MB)", vol)
 	}
+}
+
+// awaitVolumeBound waits for CXDS volume to settle at or under limit, and
+// reports the final volume either way.
+//
+// These tests assert an EVENTUAL property — that async cleanup keeps retention
+// bounded — but used to sample it once, immediately, after giving the cleanup
+// goroutine a fixed 20ms per tick to drain. That is enough on an idle machine
+// and not enough on a loaded CI runner, where the three platform lanes failed
+// on every PR while the same tests passed locally five times in a row. Polling
+// keeps exactly the property under test (retention settles within the bound)
+// and drops the assumption about how fast a background goroutine gets
+// scheduled. A real leak never settles, so it still fails — just after the
+// deadline instead of immediately.
+func awaitVolumeBound(t *testing.T, cxds interface{ Volume() (int, int) }, limit int, within time.Duration) int {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	vol, _ := cxds.Volume()
+	for time.Now().Before(deadline) {
+		if vol <= limit {
+			return vol
+		}
+		time.Sleep(100 * time.Millisecond)
+		vol, _ = cxds.Volume()
+	}
+	return vol
 }

--- a/pkg/cxo/treestore/leak_subscriber_repro_test.go
+++ b/pkg/cxo/treestore/leak_subscriber_repro_test.go
@@ -72,7 +72,8 @@ func TestPublisherCleanupBoundedWithSubscriber(t *testing.T) {
 	// One ~2 MB leaf + a handful of small structural objects per kept Root.
 	// keepLast=1 means ~4 MB steady state. 40 ticks × 2 MB = 80 MB if the
 	// per-Root cleanup is fully defeated; anything past 16 MB is the leak.
-	if vol > 16*1024*1024 {
+	const limit = 16 * 1024 * 1024
+	if vol = awaitVolumeBound(t, cxds, limit, 30*time.Second); vol > limit {
 		t.Errorf("CXDS volume %d > 16 MB — leak with a subscriber connected (per-Root retention should be ~4 MB)", vol)
 	}
 }


### PR DESCRIPTION
`TestPublisherAsyncCleanupBounded` and `TestPublisherCleanupBoundedWithSubscriber` have been failing the **linux, darwin and windows** lanes on every PR (#4815, #4816, #4818 all show the same three red), while passing locally five runs in a row.

Both assert an *eventual* property — that async cleanup keeps CXDS retention bounded — by sampling it once, immediately, after giving the cleanup goroutine a fixed `20ms` per tick to drain. Enough on an idle machine; not enough on a CI runner writing 4 MB a tick for 30 ticks under the full suite's parallel load, where the sampled volume is the cleanup backlog rather than a leak.

They now poll for the bound with a 30 s deadline. The property under test is unchanged — retention settles at or under the limit — and only the assumption about how promptly a background goroutine is scheduled is dropped. A real leak never settles, so it still fails, just after the deadline rather than immediately.

Checked that the assertion can still fail, by running it against a 1 KB bound: `CXDS volume 4195507 > 8 MB`.