### PR TITLE
flags: wash the help-screen cloud in blue and knock the rain through it

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/0magnet/router7 v0.0.0-20260908180141-0ea01e083539
 	github.com/0magnet/spheregraph v0.0.0-20260906144810-35af719bf2f1
 	github.com/0magnet/sysinfo v1.1.4-0.20260905172033-914ade4a2548
-	github.com/0magnet/termanim v0.0.0-20260912172617-9e520e861b43
+	github.com/0magnet/termanim v0.0.0-20260912180616-5fa253f0fdbd
 	github.com/0magnet/wfdrive v0.3.1
 	github.com/0magnet/winbox-go v0.0.0-20260908011106-113d480c4188
 	github.com/0magnet/yamux v0.1.3-0.20260905172050-450c4058f851

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/0magnet/spheregraph v0.0.0-20260906144810-35af719bf2f1 h1:ec89d2yMSHm
 github.com/0magnet/spheregraph v0.0.0-20260906144810-35af719bf2f1/go.mod h1:Lo6dEOjpVn+ra0q7gNWsvxxcd/SUF7Pg3dkRhykOScI=
 github.com/0magnet/sysinfo v1.1.4-0.20260905172033-914ade4a2548 h1:J7C/fYqBFSM4JF9+aRO3/s9f6uyriTQWv40sYc5p8Fg=
 github.com/0magnet/sysinfo v1.1.4-0.20260905172033-914ade4a2548/go.mod h1:X0RvvBVc0OJr+hvmABCWXQlPg7J5AUHsuqJrbBCTP8E=
-github.com/0magnet/termanim v0.0.0-20260912172617-9e520e861b43 h1:YzUN4PdlUI++o3ReMXgEEcOZu/ZIj4XoHq1SF5YONFY=
-github.com/0magnet/termanim v0.0.0-20260912172617-9e520e861b43/go.mod h1:GWNgt2KhsKUcnDh+Fes1xnCo5MgykNIIDWmC+YoMJ3o=
+github.com/0magnet/termanim v0.0.0-20260912180616-5fa253f0fdbd h1:KC5glrnMG3f6mIP2BzEiwthPnAk/I7tiDJshvIEdRt0=
+github.com/0magnet/termanim v0.0.0-20260912180616-5fa253f0fdbd/go.mod h1:GWNgt2KhsKUcnDh+Fes1xnCo5MgykNIIDWmC+YoMJ3o=
 github.com/0magnet/u-root v0.16.1-0.20260907161518-7972ea755b47 h1:uYelfGoqdFDxsKGgiIZ9/cvbrBSR+e6mA29OhVMVlFw=
 github.com/0magnet/u-root v0.16.1-0.20260907161518-7972ea755b47/go.mod h1:YBQz88D4gXBLb9++oXsiZZjfbtRC0bp4c2pduFOyZts=
 github.com/0magnet/websh v0.0.0-20260908184825-10432f75b8da h1:ZQsKIsDkjo4cejCHOATP9x3/QgzziubKJMJjbBKzPFQ=

--- a/pkg/flags/cloud.go
+++ b/pkg/flags/cloud.go
@@ -3,20 +3,23 @@
 // The cloud in the rain.
 //
 // On a terminal wide enough to have room to spare beside the help text, the
-// Skycoin cloud appears in it — not drawn over the rain but made of it. Cells
-// inside the silhouette are lit to a dim floor with the glyph the rain already
-// holds at that position, so the mark is the same alphabet scrambling in the
-// same streams, and the streams still fall visibly brighter through it.
+// Skycoin cloud appears in it — a field of the logo's own blue with the rain
+// falling through it as a knockout, the same glyphs in the same streams, drawn
+// black where they cross the mark and green everywhere else.
 //
-// Brightening the rain that was already there does not work, and the reason is
-// worth keeping: the rain is mostly gaps and its streams are vertical, so
-// scaling only the lit cells traces the streams rather than the shape. Filling
-// the silhouette to a floor is what makes it findable.
+// The color is the shape and the rain is only what passes over it. Three
+// earlier attempts had it the other way round and each failed for the same
+// reason: the rain is mostly gaps and its streams are vertical, so anything
+// that draws a shape *out of* the rain is at the mercy of where the rain
+// happens to be. Brightening the lit cells traced the streams. Filling the
+// dark ones with the rain's glyphs made a picture out of katakana. Recoloring
+// only the lit cells was the prettiest and the least legible of the three.
 //
 // The shape is Skycoin's own, from the logo skycoin/skycoin serves in its block
 // explorer — a cloud cut by diagonal slashes. The slashes are what distinguish
 // it from any other cloud, and they are also what costs the resolution: see
-// gencloud for why there is no small variant.
+// gencloud for why there is no small variant. They survive at one cell wide
+// here because the wash does not depend on a stream falling in them.
 //
 // It costs nothing when there is no room. The whole thing is gated on width:
 // the help text is wrapped to a hardcoded 80 columns (see HelpWidth), which is
@@ -43,30 +46,10 @@ const (
 	// cloudRowRoom is the rows that must be left over after the logo, so it
 	// never fills the screen top to bottom.
 	cloudRowRoom = 2
-
-	// cloudFloor is the least the rain may be inside the shape, on the 0-255
-	// scale its palette is indexed by.
-	//
-	// This is what makes the logo legible. Brightening the cells the rain
-	// already lit is not enough on its own — the rain is mostly gaps and its
-	// streams run vertically, so brightening traces the streams and not the
-	// shape. Lighting every cell inside the silhouette to a dim floor draws
-	// the outline; the streams still fall through it at their own brightness,
-	// four times this and up, so the shape reads as rain that is denser here
-	// rather than as a panel behind the rain.
-	//
-	// 95 against trails that run to 200. The mark is a cloud cut by diagonal
-	// slashes, and the slashes are the part that identifies it: they are one or
-	// two cells wide, which is also the width of the rain's own gaps, so the
-	// filled bands have to sit clearly above an ordinary trail cell or the
-	// slashes read as more rain. Higher flattens the streams into an even block
-	// and loses the weather; lower and the mark stops being a Skycoin cloud and
-	// becomes a cloud.
-	cloudFloor = 95
 )
 
-// cloudMask brightens the rain inside the logo's silhouette, when there is
-// room for it beside the help text.
+// cloudMask washes the logo's silhouette in Skycoin blue and knocks the rain
+// through it in black, when there is room for it beside the help text.
 //
 // It implements backdrop.Fitter because neither half of the placement can be
 // known when the options are built: the screen width is settled inside the
@@ -108,7 +91,7 @@ func (c *cloudMask) Fit(cols, rows int) {
 
 	for i := len(cloudShapes) - 1; i >= 0; i-- {
 		shape := cloudShapes[i]
-		st := backdrop.Stencil{Rows: shape, Floor: cloudFloor}
+		st := backdrop.Stencil{Rows: shape}
 		w, h := st.Size()
 		if w > free || h+cloudRowRoom > rows {
 			continue
@@ -120,37 +103,57 @@ func (c *cloudMask) Fit(cols, rows int) {
 	}
 }
 
-// TintAt implements backdrop.Tinter: inside the silhouette the rain runs
-// Skycoin blue instead of green.
+// WashAt implements backdrop.Washer: the silhouette is a solid field of
+// Skycoin blue, painted whether or not the rain lit the cell.
 //
-// This is what makes the logo findable at a glance. Brightness alone leaves it
-// green among green — a shape you can see once you know it is there and lose
-// the moment you look away, which is not much of an easter egg. The mark has a
-// color of its own, and borrowing it separates the cloud from the rain while
-// the glyphs, their scrambling and their falling stay exactly what they were.
+// This is what finally makes the mark read, and it took three tries to get
+// here. Brightening the rain inside the shape traced the streams instead of
+// the shape, because the streams are vertical and the shape is not. Lighting
+// the shape's dark cells with the rain's own glyphs made it solid but turned
+// it into a picture made of katakana rather than rain. Recoloring only the
+// cells the rain lit was prettiest and least legible of all: the rain is
+// mostly gaps, so the mark came out as a handful of blue smears.
 //
-// The cell's own brightness is carried over rather than replaced: the green is
-// reduced to a level and that level is applied to the blue, so trails still
-// read as trails and the hot heads still flare inside the shape. A flat fill
-// would turn the logo into a panel, which is the thing this has avoided all
-// along.
+// Painting the background leaves the rain exactly as sparse as it was and
+// makes the region solid anyway. The outline is crisp and the diagonal slashes
+// survive at one cell wide, because neither depends on a stream happening to
+// fall there.
+func (c *cloudMask) WashAt(x, y int) (int32, int32, int32, bool) {
+	if !c.on || !c.st.Covers(x, y) {
+		return 0, 0, 0, false
+	}
+	return cloudR, cloudG, cloudB, true
+}
+
+// TintAt implements backdrop.Tinter: the rain crossing the silhouette is drawn
+// black, so it reads as a knockout through the blue rather than as glyphs laid
+// on top of it.
+//
+// Black rather than a darkened green: against the wash the point is contrast,
+// not hue, and the rain keeps its shape — the same glyphs in the same streams,
+// scrambling as they always do — while the color behind them is the logo. What
+// falls through the slashes stays green, which is what keeps the mark looking
+// like weather passing behind something rather than a panel with a pattern.
 func (c *cloudMask) TintAt(x, y int, r, g, b int32) (int32, int32, int32) {
 	if !c.on || !c.st.Covers(x, y) {
 		return r, g, b
 	}
-	// Luma of the green the palette gave this cell, as a 0-255 level. The ramp
-	// is overwhelmingly green, so this tracks the trail's falloff closely while
-	// still lifting the white-hot heads.
-	lvl := (r*30 + g*59 + b*11) / 100
-	return cloudR * lvl / 255, cloudG * lvl / 255, cloudB * lvl / 255
+	return 0, 0, 0
 }
 
-// The Skycoin blue the silhouette is drawn in, #0072ff — the fill color of the
-// logo gencloud sampled the shape from.
+// The blue the silhouette is washed in: #002d66, the logo's own #0072ff taken
+// down to something that sits behind the rain rather than in front of it.
+//
+// Dimmed because it can be. The shape comes from the wash covering every cell
+// of the silhouette, not from the color being loud, so the mark stays exactly
+// as crisp at a fifth of the brightness — the slashes are cut by which cells
+// are washed, and that does not change. At full strength the cloud reads as a
+// panel bolted over the screen; at this one it reads as something the rain is
+// falling in front of, which is the effect worth having.
 const (
 	cloudR = 0x00
-	cloudG = 0x72
-	cloudB = 0xff
+	cloudG = 0x2d
+	cloudB = 0x66
 )
 
 // IntensityAt implements backdrop.Mask. With no room found, every cell is

--- a/vendor/github.com/0magnet/termanim/matrix/backdrop/cell.go
+++ b/vendor/github.com/0magnet/termanim/matrix/backdrop/cell.go
@@ -141,9 +141,18 @@ func (f *Frame) FromMatrix(m *matrix.Matrix, dim int) {
 		for x := 0; x < f.cols; x++ {
 			c, lit := m.CellAt(x, y)
 			n := maskIntensity(f.mask, x, y, clamp255(scale(c.Intensity, dim)))
+			bg, washed := washAt(f.mask, x, y)
+
 			if n <= 0 {
+				// Dark, but a wash is still a reason to draw: a space in the
+				// washed color is what makes a shape solid where the backdrop
+				// is only gaps. Without one there is nothing here at all.
+				if washed {
+					f.Set(x, y, Cell{Rune: ' ', Bg: bg})
+				}
 				continue
 			}
+
 			r := c.Rune
 			if !lit {
 				// The rain holds a glyph in every cell whether it is lighting
@@ -152,7 +161,12 @@ func (f *Frame) FromMatrix(m *matrix.Matrix, dim int) {
 				// rain that is denser here rather than as something stamped on.
 				r = m.GlyphAt(x, y)
 			}
-			f.Set(x, y, Cell{Rune: r, Fg: tintAt(f.mask, x, y, pal[n]), Bold: c.Hot && lit})
+			f.Set(x, y, Cell{
+				Rune: r,
+				Fg:   tintAt(f.mask, x, y, pal[n]),
+				Bg:   bg,
+				Bold: c.Hot && lit,
+			})
 		}
 	}
 }

--- a/vendor/github.com/0magnet/termanim/matrix/backdrop/mask.go
+++ b/vendor/github.com/0magnet/termanim/matrix/backdrop/mask.go
@@ -221,3 +221,42 @@ func clampChan(v int32) int32 {
 	}
 	return v
 }
+
+// Washer is a Mask that paints a background behind the cells it covers,
+// whether or not the backdrop lit them.
+//
+// It is what a shape needs when the thing behind the text is too sparse to
+// carry it. A mask that can only brighten or recolor is at the mercy of where
+// the rain happens to be falling: the streams are vertical and mostly gaps, so
+// a silhouette drawn only in lit cells comes out as vertical smears, and one
+// filled in with invented glyphs stops being rain. A wash sidesteps both — the
+// region is solid because the background is solid, and the rain stays exactly
+// as sparse as it was, reading as a knockout through the color rather than as
+// something added to it.
+//
+// WashAt returns the background for a cell and whether there is one at all;
+// false leaves the terminal's own background showing, which is what every cell
+// outside a shape wants. A cell with a wash is drawn even when the backdrop
+// left it dark — as a space, so the wash is all there is to see — which is the
+// property that makes the shape solid.
+//
+// Optional, like Fitter and Tinter.
+type Washer interface {
+	Mask
+
+	// WashAt returns the background at x, y, and whether to paint one.
+	WashAt(x, y int) (r, g, b int32, ok bool)
+}
+
+// washAt applies a possibly-absent wash, clamped like a tint.
+func washAt(m Mask, x, y int) (tcell.Color, bool) {
+	w, ok := m.(Washer)
+	if !ok {
+		return tcell.ColorDefault, false
+	}
+	r, g, b, on := w.WashAt(x, y)
+	if !on {
+		return tcell.ColorDefault, false
+	}
+	return tcell.NewRGBColor(clampChan(r), clampChan(g), clampChan(b)), true
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -117,7 +117,7 @@ github.com/0magnet/spheregraph
 ## explicit; go 1.22
 github.com/0magnet/sysinfo
 github.com/0magnet/sysinfo/cpuid
-# github.com/0magnet/termanim v0.0.0-20260912172617-9e520e861b43
+# github.com/0magnet/termanim v0.0.0-20260912180616-5fa253f0fdbd
 ## explicit; go 1.26.0
 github.com/0magnet/termanim/canvas
 github.com/0magnet/termanim/matrix


### PR DESCRIPTION
**Did you run `make format && make check`?** `go build ./...`, `go test`, `golangci-lint` (0 issues), `make check-help`, `go mod tidy` verified stable by snapshot-and-compare. The full `make check` needs a Docker daemon and Redis on :6379 for the e2e/integration/store suites; this machine has neither, and those fail identically on unmodified develop.

**Changes:**

Follow-up to #4818. The cloud was still being drawn *out of* the rain, and the rain is the wrong material for it — mostly gaps, and what is there falls in vertical streams. Three approaches all broke on that same fact:

- brightening the lit cells traced the streams, not the shape;
- lighting the dark cells with the rain's own glyphs made it solid, but turned a logo into a picture made of katakana;
- recoloring only the lit cells was the prettiest and the least legible — the mark came out as a few blue smears.

Inverting it fixes all three. The silhouette is a washed **background**, painted whether or not a stream falls there, and the rain crossing it is drawn black. The color is the shape; the rain is only what passes over it. The outline is crisp and the diagonal slashes survive at one cell wide, because neither depends any more on where the rain happens to be. What falls through the slashes stays green.

The wash is `#002d66` rather than the logo's `#0072ff`. It can afford to be dim because the shape comes from which cells are covered rather than from the color being loud — the mark is exactly as crisp at a fifth of the brightness, and at full strength it reads as a panel bolted over the screen rather than something the rain falls in front of.

This needed `backdrop.Washer` upstream in `0magnet/termanim`: a mask could set a foreground but not a background, and could not paint a cell the backdrop left dark without inventing a glyph for it.

No behavior change outside the help screen. `SKYWIRE_NO_HELP_RAIN`, `NO_COLOR`, a pipe, machine mode and `help -r`/`-d` switch it off as before; below 118 columns the mask still hands every cell back untouched.

Written with AI assistance.

**How to test this PR:**

```
stty cols 160 rows 60; go run . cli --help
```

Requires a terminal with truecolor background support. `#0072ff` in `cloud.go` is the one-constant change back to the bold version.