### PR TITLE
feat(visor): report the clients connected to the in-process dmsg server

### DIFF
--- a/pkg/dmsg/dmsg/server.go
+++ b/pkg/dmsg/dmsg/server.go
@@ -227,6 +227,12 @@ func NewServer(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, conf *Serv
 	return s
 }
 
+// IsPeerPK reports whether pk is a known peer SERVER rather than a client.
+// Exported so a co-resident visor can separate the two when it reports what
+// its in-process server is holding: a server-to-server link counted as a
+// client makes the server look busier than it is.
+func (s *Server) IsPeerPK(pk cipher.PubKey) bool { return s.isPeerPK(pk) }
+
 // GetSessions returns underlying sessions map.
 func (s *Server) GetSessions() map[cipher.PubKey]*SessionCommon {
 	s.sessionsMx.Lock()

--- a/pkg/visor/api_state_roles.go
+++ b/pkg/visor/api_state_roles.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
@@ -69,6 +70,32 @@ type DmsgServerRole struct {
 	ConfigPath          string `json:"config_path,omitempty"`
 	// StartedAt is when the server was started (zero when it is not running).
 	StartedAt time.Time `json:"started_at,omitempty"`
+	// SessionCount is how many dmsg sessions this server currently holds, and
+	// Clients names them. Answering "who is actually on this dmsg server" used
+	// to require asking the discovery — which reports what CLIENTS claim about
+	// their delegated servers, not what the server itself is holding, and says
+	// nothing about how much traffic each one is running. A co-resident visor
+	// knows the real answer; this reports it.
+	//
+	// Peers are separated from ordinary clients because a server-to-server link
+	// is not a client at all: counting the two together makes a server look
+	// busier than it is, and the peer mesh is the part an operator tunes
+	// separately.
+	//
+	// Only populated in own_key mode — config_path mode runs the server inside
+	// an unexported service type that exposes no session handle.
+	SessionCount int                `json:"session_count"`
+	PeerCount    int                `json:"peer_count"`
+	Clients      []DmsgServerClient `json:"clients,omitempty"`
+}
+
+// DmsgServerClient is one session held by this visor's in-process dmsg server:
+// the connected key, how many streams it has open, and whether the session is
+// another dmsg server (a peer link) rather than a client.
+type DmsgServerClient struct {
+	PK      cipher.PubKey `json:"pk"`
+	Streams int           `json:"streams"`
+	Peer    bool          `json:"peer,omitempty"`
 }
 
 // DmsgRelayRole is both directions of the dmsg relay: the relays this visor
@@ -130,6 +157,9 @@ type dmsgSessionView struct {
 // zero-valued rather than failing.
 func (v *Visor) RolesSnapshot() *RolesSnapshot {
 	r := &RolesSnapshot{DmsgServer: dmsgServerRole(v.conf, v.dmsgSrvRole.Load())}
+	if srv := v.dmsgSrv.Load(); srv != nil {
+		r.DmsgServer.SessionCount, r.DmsgServer.PeerCount, r.DmsgServer.Clients = dmsgServerSessions(srv)
+	}
 	if v.conf != nil {
 		r.PK = confPK(v.conf)
 		if v.conf.Routing != nil {
@@ -251,4 +281,36 @@ func dmsgRelayRole(port uint16, nominees []cipher.PubKey, sessions []dmsgSession
 		return role.RelayClients[i].PK.String() < role.RelayClients[j].PK.String()
 	})
 	return role
+}
+
+// dmsgServerSessions snapshots what the in-process dmsg server is holding:
+// the total session count, how many of those are peer servers rather than
+// clients, and a stable-ordered list naming each one with its open streams.
+//
+// This is the server's own view. The discovery's is not a substitute: an entry
+// records what a CLIENT claims about the servers it delegated to, so it is
+// self-reported, lags reality by the entry refresh interval, and carries no
+// per-client stream count at all. For "which clients is this server actually
+// carrying, and how hard", only the server knows.
+func dmsgServerSessions(srv *dmsg.Server) (total, peers int, clients []DmsgServerClient) {
+	sessions := srv.GetSessions()
+	clients = make([]DmsgServerClient, 0, len(sessions))
+	for pk, ses := range sessions {
+		if ses == nil {
+			continue
+		}
+		isPeer := srv.IsPeerPK(pk)
+		if isPeer {
+			peers++
+		}
+		clients = append(clients, DmsgServerClient{
+			PK:      pk,
+			Streams: ses.NumStreams(),
+			Peer:    isPeer,
+		})
+	}
+	// Stable order: a caller diffing two snapshots must not see map iteration
+	// masquerading as churn.
+	sort.Slice(clients, func(i, j int) bool { return clients[i].PK.String() < clients[j].PK.String() })
+	return len(clients), peers, clients
 }

--- a/pkg/visor/api_state_roles_dmsgsrv_test.go
+++ b/pkg/visor/api_state_roles_dmsgsrv_test.go
@@ -1,0 +1,89 @@
+// Package visor pkg/visor/api_state_roles_dmsgsrv_test.go c3-vis-api
+package visor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/nettest"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	dmsgdisc "github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+)
+
+// TestDmsgServerSessionsReportsConnectedClients covers the question the
+// discovery cannot answer: which clients is this server actually holding, and
+// how many streams is each running.
+//
+// A discovery entry records what a CLIENT claims about the servers it
+// delegated to — self-reported, refresh-interval stale, and with no stream
+// counts. A co-resident visor has the server's own view, and this is how it
+// reports it.
+func TestDmsgServerSessionsReportsConnectedClients(t *testing.T) {
+	srvPK, srvSK := cipher.GenerateKeyPair()
+	lis, err := nettest.NewLocalListener("tcp")
+	require.NoError(t, err)
+
+	dc := dmsgdisc.NewMock(0)
+	srv := dmsg.NewServer(srvPK, srvSK, dc, &dmsg.ServerConfig{
+		MaxSessions:    10,
+		UpdateInterval: dmsg.DefaultUpdateInterval,
+	}, nil)
+	go func() { _ = srv.Serve(lis, "") }() //nolint:errcheck
+	t.Cleanup(func() { _ = srv.Close() })  //nolint:errcheck
+
+	select {
+	case <-srv.Ready():
+	case <-time.After(20 * time.Second):
+		t.Fatal("dmsg test server did not become ready")
+	}
+
+	// An idle server holds nothing, and must say so with an empty list rather
+	// than a nil-vs-empty distinction a caller has to guess at.
+	total, peers, clients := dmsgServerSessions(srv)
+	require.Zero(t, total)
+	require.Zero(t, peers)
+	require.Empty(t, clients)
+
+	// Two clients on the same server: the count must be the server's, not a
+	// per-client guess.
+	var pks []cipher.PubKey
+	for i := 0; i < 2; i++ {
+		cPK, cSK := cipher.GenerateKeyPair()
+		pks = append(pks, cPK)
+		c := dmsg.NewClient(cPK, cSK, dc, &dmsg.Config{MinSessions: 1})
+		go c.Serve(t.Context())             //nolint:errcheck
+		t.Cleanup(func() { _ = c.Close() }) //nolint:errcheck
+		select {
+		case <-c.Ready():
+		case <-time.After(20 * time.Second):
+			t.Fatalf("client %d never became ready", i)
+		}
+	}
+
+	require.Eventually(t, func() bool {
+		total, _, _ = dmsgServerSessions(srv)
+		return total == 2
+	}, 20*time.Second, 100*time.Millisecond, "server must report both connected clients")
+
+	total, peers, clients = dmsgServerSessions(srv)
+	require.Equal(t, 2, total)
+	require.Len(t, clients, 2)
+	require.Zero(t, peers, "plain clients are not peer servers")
+
+	seen := map[cipher.PubKey]bool{}
+	for _, c := range clients {
+		require.False(t, c.Peer, "client %s wrongly classified as a peer server", c.PK)
+		require.GreaterOrEqual(t, c.Streams, 0)
+		seen[c.PK] = true
+	}
+	for _, pk := range pks {
+		require.True(t, seen[pk], "connected client %s missing from the report", pk)
+	}
+
+	// Stable order, so a caller diffing two snapshots does not see map
+	// iteration masquerading as churn.
+	require.True(t, clients[0].PK.String() < clients[1].PK.String(), "clients must be ordered by key")
+}

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -1126,6 +1126,7 @@ func initDmsgServer(ctx context.Context, v *Visor, log *logging.Logger) error {
 		WithField("shared_transport_port", shared).
 		Info("Started in-process dmsg server on the visor key")
 
+	v.dmsgSrv.Store(srv)
 	v.dmsgSrvRole.Store(&DmsgServerRole{
 		Mode:                dmsgServerModeOwnKey,
 		PK:                  v.conf.PK,
@@ -1138,6 +1139,7 @@ func initDmsgServer(ctx context.Context, v *Visor, log *logging.Logger) error {
 
 	v.pushCloseStack("dmsg_server", func() error {
 		v.dmsgSrvRole.Store(nil)
+		v.dmsgSrv.Store(nil)
 		cerr := srv.Close()
 		// Only a listener this server owns is closed here. The shared branch
 		// belongs to the transport cmux, which stcpr and WS are still serving;

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -149,6 +149,12 @@ type Visor struct {
 	// server's key and address rather than only what the config asked for.
 	dmsgSrvRole atomic.Pointer[DmsgServerRole]
 
+	// dmsgSrv is the running own-key in-process dmsg server, kept so the
+	// state API can report the clients CONNECTED TO it. Every co-resident
+	// visor+server ("hub") runs this mode; config_path mode keeps the server
+	// inside an unexported service type and stores nothing here.
+	dmsgSrv atomic.Pointer[dmsg.Server]
+
 	// localGraph is an extra transport-graph source merged into every
 	// GetAllTransports answer (see local_graph.go).
 	localGraphMu sync.RWMutex


### PR DESCRIPTION
"Which clients is this dmsg server actually carrying, and how hard?" had no good answer. The discovery is not one: an entry records what a **client** claims about the servers it delegated to — self-reported, stale by the refresh interval, and with no per-client stream count at all.

Every co-resident visor+server knows the real answer, and `visor state --select roles` already reports that server’s key, mode and address; it just never reported what it was holding. Now it does:

```
"dmsg_server": {
  "enabled": true, "running": true, "mode": "own_key", "own_key": true,
  "session_count": 42, "peer_count": 6,
  "clients": [{"pk": "02…", "streams": 3}, {"pk": "03…", "streams": 0, "peer": true}]
}
```

Peer links are counted separately — a server-to-server link is not a client, and folding the two together makes a server look busier than it is while hiding the peer mesh, which is tuned separately.

Only `own_key` mode is covered, which is every hub (7 of the 9 servers currently advertise both a Client and a Server section). `config_path` mode runs the server inside an unexported service type that exposes no session handle; the field comment says so rather than reporting a silent zero.

`dmsg.Server.IsPeerPK` is exported for the classification — `GetSessions` and `SessionCommon.NumStreams` already were. The client list is sorted by key so a caller diffing two snapshots does not see map iteration as churn. Test drives a real server with two real clients connected.

Reachable per-visor as `cli --via dmsg://<pk> visor state --select roles --jq .roles.dmsg_server`.