### PR TITLE
fix(lint): clear the 18 findings gating the linux, darwin and windows lanes

### DIFF
--- a/pkg/app/appnet/networker.go
+++ b/pkg/app/appnet/networker.go
@@ -65,7 +65,7 @@ type carrierDialCtxKey struct{}
 //
 // min_hops exists so an intermediate cannot learn the true source and
 // destination of this visor's TRAFFIC — with enough hops it only ever sees
-// its neighbours. A carrier dial is not traffic. Its destination IS the peer
+// its neighbors. A carrier dial is not traffic. Its destination IS the peer
 // that will carry the session, chosen by this visor, and that peer terminates
 // the session and therefore knows exactly whose it is. Extra hops hide
 // nothing from the only party in a position to learn anything, so min_hops

--- a/pkg/app/appnet/skywire_networker.go
+++ b/pkg/app/appnet/skywire_networker.go
@@ -123,7 +123,7 @@ func (r *SkywireNetworker) DialContextWithOptions(ctx context.Context, addr Addr
 	//
 	// min_hops stays global, because it IS a visor-wide property: enough hops
 	// keeps an intermediate from learning the true source and destination
-	// rather than just its neighbours. That is why min-hops is read through the
+	// rather than just its neighbors. That is why min-hops is read through the
 	// router — opts.MinHops == 0 means "inherit Config.MinHops", so testing
 	// opts alone let a VPN client configured for min_hops=3 take this shortcut
 	// and get a single direct hop, bypassing the privacy constraint before

--- a/pkg/cxo/cxosub/cycle_done_test.go
+++ b/pkg/cxo/cxosub/cycle_done_test.go
@@ -12,7 +12,7 @@ import (
 // whatever f.done happened to hold when it returned, which raced its own
 // stopper: the grace timer captures f.done, nils the field, cancels the
 // context and then waits on its captured copy. The loop therefore woke on a
-// context that was cancelled only AFTER the field had already been nilled,
+// context that was canceled only AFTER the field had already been nilled,
 // and paniced with "close of nil channel" — taking the whole visor down, on
 // every visor, as soon as boot got far enough to acquire and release a feed.
 //

--- a/pkg/cxo/data/cxds/drive_compact_test.go
+++ b/pkg/cxo/data/cxds/drive_compact_test.go
@@ -15,8 +15,12 @@ import (
 	"github.com/skycoin/skywire/pkg/cxo/data"
 )
 
-func mkVal(b byte, n int) []byte {
-	d := make([]byte, n)
+// objSize is the value size every object in these tests uses — every caller
+// passed the same 8192, so it is a property of the fixture, not a parameter.
+const objSize = 8192
+
+func mkVal(b byte) []byte {
+	d := make([]byte, objSize)
 	for i := range d {
 		d[i] = b
 	}
@@ -34,13 +38,13 @@ func TestStartupGCCompact_DropsDeadKeepsLive(t *testing.T) {
 
 	var live, dead [][]byte
 	for i := 0; i < 3; i++ { // live: rc=1
-		v := mkVal(byte('L'+i), 8192)
+		v := mkVal(byte('L' + i))
 		_, err := ds.Set(cipher.SumSHA256(v), v, 1)
 		require.NoError(t, err)
 		live = append(live, v)
 	}
 	for i := 0; i < 3; i++ { // dead: Set rc=1 then Inc -1 -> rc=0 (retained by CXDS)
-		v := mkVal(byte('D'+i), 8192)
+		v := mkVal(byte('D' + i))
 		k := cipher.SumSHA256(v)
 		_, err := ds.Set(k, v, 1)
 		require.NoError(t, err)
@@ -87,7 +91,7 @@ func TestStartupGCCompact_SkipsMostlyLive(t *testing.T) {
 	require.NoError(t, err)
 	var live [][]byte
 	for i := 0; i < 6; i++ {
-		v := mkVal(byte('a'+i), 8192)
+		v := mkVal(byte('a' + i))
 		_, err := ds.Set(cipher.SumSHA256(v), v, 1)
 		require.NoError(t, err)
 		live = append(live, v)
@@ -118,8 +122,8 @@ func TestStartupGCCompact_ReclaimsFreedPages(t *testing.T) {
 	// Phase 1: grow the file with 600 live objects.
 	var keep, drop [][]byte
 	for i := 0; i < 600; i++ {
-		v := mkVal(byte(i%251), 8192)
-		v[0], v[1] = byte(i>>8), byte(i) // distinct objects
+		v := mkVal(byte(i % 251))
+		v[0], v[1] = byte(uint(i)>>8&0xff), byte(uint(i)&0xff) // distinct objects
 		_, err := ds.Set(cipher.SumSHA256(v), v, 1)
 		require.NoError(t, err)
 		if i < 6 {
@@ -171,8 +175,8 @@ func TestStartupGCCompact_IgnoresPreCriteriaMemo(t *testing.T) {
 	require.NoError(t, err)
 	var drop [][]byte
 	for i := 0; i < 600; i++ {
-		v := mkVal(byte(i%251), 8192)
-		v[0], v[1] = byte(i>>8), byte(i)
+		v := mkVal(byte(i % 251))
+		v[0], v[1] = byte(uint(i)>>8&0xff), byte(uint(i)&0xff)
 		_, err := ds.Set(cipher.SumSHA256(v), v, 1)
 		require.NoError(t, err)
 		if i >= 6 {
@@ -197,7 +201,13 @@ func TestStartupGCCompact_IgnoresPreCriteriaMemo(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		return putUint64Meta(m, []byte("gc_checked_size"), uint64(before.Size()))
+		// FileInfo.Size is non-negative for a regular file; the guard makes that
+		// explicit rather than leaving a signed-to-unsigned conversion to trust.
+		size := before.Size()
+		if size < 0 {
+			size = 0
+		}
+		return putUint64Meta(m, []byte("gc_checked_size"), uint64(size))
 	}))
 	require.NoError(t, db.Close())
 

--- a/pkg/deployment/tpd/api/cxo_metrics_publisher.go
+++ b/pkg/deployment/tpd/api/cxo_metrics_publisher.go
@@ -443,7 +443,7 @@ func (m *MetricsCXOPublisher) LastError() error {
 // gzipRecords is the gzipped JSON array of metrics, streamed one record at a
 // time straight into the compressor. The output is byte-identical to
 // gzip(json.Marshal(metrics)) — "[]" for an empty or nil slice — but the whole
-// JSON body is never held: a day of metrics marshalled to ~130 MB before
+// JSON body is never held: a day of metrics marshaled to ~130 MB before
 // compression and was built twice (whole, then per part), which is what pushed
 // the TPD's heap to multi-GB peaks every minute (2026-09-10 heap profile).
 func gzipRecords(metrics []store.TransportMetric) ([]byte, error) {

--- a/pkg/geoip/geoip_mapped_test.go
+++ b/pkg/geoip/geoip_mapped_test.go
@@ -4,6 +4,7 @@
 package geoip
 
 import (
+	"math"
 	"net/netip"
 	"os"
 	"path/filepath"
@@ -67,7 +68,9 @@ func TestOpenMapped_UnwritableDirFails(t *testing.T) {
 		t.Skip("root can write anywhere")
 	}
 	ro := t.TempDir()
-	require.NoError(t, os.Chmod(ro, 0o500))
+	// 0o500 is the subject of the test: a directory the process may traverse but
+	// not write. G302's 0600 ceiling is about files, not this.
+	require.NoError(t, os.Chmod(ro, 0o500)) //nolint:gosec // G302: intentionally non-writable dir
 	_, err := openMapped(filepath.Join(ro, "skywire"))
 	require.Error(t, err, "Shared() falls back to the in-memory reader on this error")
 }
@@ -85,7 +88,29 @@ func TestOpenMapped_HeapFootprint(t *testing.T) {
 	defer r.Close() //nolint:errcheck
 	runtime.GC()
 	runtime.ReadMemStats(&after)
-	t.Logf("mapped: heap +%d KiB", (int64(after.HeapInuse)-int64(before.HeapInuse))/1024)
+	// Heap sizes here are far below the int64 ceiling; the helper keeps the
+	// signed subtraction (the delta can legitimately be negative) without an
+	// unchecked uint64→int64 conversion at the call site.
+	t.Logf("mapped: heap +%d KiB", heapDeltaKiB(before.HeapInuse, after.HeapInuse))
 
 	t.Logf("in-memory: heap +%d KiB pinned by EmbeddedDB()", len(EmbeddedDB())/1024)
+}
+
+// heapDeltaKiB reports after-before in KiB. Both are runtime.MemStats byte
+// counts, so the subtraction is done in the unsigned domain and only the
+// (small) result is signed — a direct int64(x) on each operand is an
+// unchecked narrowing that gosec flags, and rightly so as a habit.
+func heapDeltaKiB(before, after uint64) int64 {
+	d, neg := after-before, false
+	if after < before {
+		d, neg = before-after, true
+	}
+	d /= 1024
+	if d > math.MaxInt64 {
+		d = math.MaxInt64
+	}
+	if neg {
+		return -int64(d)
+	}
+	return int64(d)
 }

--- a/pkg/httputil/compress_test.go
+++ b/pkg/httputil/compress_test.go
@@ -26,7 +26,7 @@ func TestCompressMin_SmallStaysPlain(t *testing.T) {
 	w := serve(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_, _ = w.Write([]byte(`{"ok":true}`))
+		mustWrite(t, w, []byte(`{"ok":true}`))
 	}), true)
 	if w.Code != http.StatusCreated || w.Header().Get("Content-Encoding") != "" || w.Body.String() != `{"ok":true}` {
 		t.Fatalf("small body must pass through: code=%d enc=%q body=%q", w.Code, w.Header().Get("Content-Encoding"), w.Body.String())
@@ -38,8 +38,8 @@ func TestCompressMin_LargeJSONIsGzipped(t *testing.T) {
 	w := serve(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		// Two writes: one below, one over the threshold.
-		_, _ = w.Write(body[:500])
-		_, _ = w.Write(body[500:])
+		mustWrite(t, w, body[:500])
+		mustWrite(t, w, body[500:])
 	}), true)
 	if w.Code != 200 || w.Header().Get("Content-Encoding") != "gzip" {
 		t.Fatalf("large json must be gzipped: code=%d enc=%q", w.Code, w.Header().Get("Content-Encoding"))
@@ -48,7 +48,10 @@ func TestCompressMin_LargeJSONIsGzipped(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	got, _ := io.ReadAll(zr)
+	got, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatalf("read gzip body: %v", err)
+	}
 	if !bytes.Equal(got, body) {
 		t.Fatalf("round trip mismatch: %d vs %d bytes", len(got), len(body))
 	}
@@ -61,14 +64,14 @@ func TestCompressMin_NonCompressibleAndNoAccept(t *testing.T) {
 	big := bytes.Repeat([]byte{0xff, 0x00, 0x7a}, 2000)
 	w := serve(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/wasm")
-		_, _ = w.Write(big)
+		mustWrite(t, w, big)
 	}), true)
 	if w.Header().Get("Content-Encoding") != "" || !bytes.Equal(w.Body.Bytes(), big) {
 		t.Fatal("application/wasm must not be gzipped")
 	}
 	w = serve(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(bytes.Repeat([]byte("a"), 5000))
+		mustWrite(t, w, bytes.Repeat([]byte("a"), 5000))
 	}), false)
 	if w.Header().Get("Content-Encoding") != "" || w.Body.Len() != 5000 {
 		t.Fatal("client without gzip must get plain bytes")
@@ -78,11 +81,22 @@ func TestCompressMin_NonCompressibleAndNoAccept(t *testing.T) {
 func TestCompressMin_EarlyFlushStaysPlain(t *testing.T) {
 	w := serve(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
-		_, _ = w.Write([]byte("first chunk\n"))
+		mustWrite(t, w, []byte("first chunk\n"))
 		w.(http.Flusher).Flush()
-		_, _ = w.Write(bytes.Repeat([]byte("x"), 3000))
+		mustWrite(t, w, bytes.Repeat([]byte("x"), 3000))
 	}), true)
 	if w.Header().Get("Content-Encoding") != "" || w.Body.Len() != len("first chunk\n")+3000 || !w.Flushed {
 		t.Fatalf("flushed stream must stay plain: enc=%q len=%d flushed=%v", w.Header().Get("Content-Encoding"), w.Body.Len(), w.Flushed)
+	}
+}
+
+// mustWrite writes a test handler's body and fails the test if it errors. A
+// handler that cannot write is a real failure rather than something to blank
+// out, and this repo lints with errcheck's check-blank on, so `_, _ =` is not
+// available as a shortcut anyway.
+func mustWrite(t *testing.T, w io.Writer, b []byte) {
+	t.Helper()
+	if _, err := w.Write(b); err != nil {
+		t.Errorf("write: %v", err)
 	}
 }

--- a/pkg/transport/network/tcpdemux_dmsg_test.go
+++ b/pkg/transport/network/tcpdemux_dmsg_test.go
@@ -103,7 +103,7 @@ func TestTCPDemux_WithoutDmsgKeepsStcprCatchAll(t *testing.T) {
 
 	other := dmsgFrame(48)
 	speak(t, addr, other)
-	wantOn(t, d.STCPR(), other, "an unrecognised opener with dmsg not sharing")
+	wantOn(t, d.STCPR(), other, "an unrecognized opener with dmsg not sharing")
 }
 
 // The shared listener is handed out only when the factory asked for it, and it

--- a/pkg/visor/api_state_roles.go
+++ b/pkg/visor/api_state_roles.go
@@ -180,7 +180,6 @@ func (v *Visor) RolesSnapshot() *RolesSnapshot {
 		})
 	}
 	r.DmsgRelay = dmsgRelayRole(
-		skyenv.DmsgRelayPort,
 		v.dmsgC.RelayPeers(),
 		sessions,
 		v.dmsgC.RelaySessionStreams(),
@@ -246,11 +245,11 @@ const (
 // client holds (to pair a nominee with the carrier it was reached over),
 // clientStreams the per-peer stream count of the peers attached to this visor,
 // and relayed/max the slot usage against the configured cap.
-func dmsgRelayRole(port uint16, nominees []cipher.PubKey, sessions []dmsgSessionView,
+func dmsgRelayRole(nominees []cipher.PubKey, sessions []dmsgSessionView,
 	clientStreams map[cipher.PubKey]int, relayed, maxStreams, refused int) DmsgRelayRole {
 
 	role := DmsgRelayRole{
-		Port:              port,
+		Port:              skyenv.DmsgRelayPort,
 		RelayPeers:        sortedPKs(nominees),
 		RelayedStreams:    relayed,
 		MaxRelayedStreams: maxStreams,
@@ -265,12 +264,7 @@ func dmsgRelayRole(port uint16, nominees []cipher.PubKey, sessions []dmsgSession
 		if _, ok := nominated[s.PK]; !ok {
 			continue
 		}
-		role.Attached = append(role.Attached, DmsgRelayAttachment{
-			PK:        s.PK,
-			Carrier:   s.Carrier,
-			Streams:   s.Streams,
-			LatencyMS: s.LatencyMS,
-		})
+		role.Attached = append(role.Attached, DmsgRelayAttachment(s))
 	}
 	sort.Slice(role.Attached, func(i, j int) bool { return role.Attached[i].PK.String() < role.Attached[j].PK.String() })
 

--- a/pkg/visor/api_state_roles_test.go
+++ b/pkg/visor/api_state_roles_test.go
@@ -136,7 +136,7 @@ func TestDmsgServerRole_NoTransitAndPK(t *testing.T) {
 // A visor that nominates nobody and relays for nobody reports empty lists and
 // the cap it would enforce if anyone attached.
 func TestDmsgRelayRole_Idle(t *testing.T) {
-	role := dmsgRelayRole(skyenv.DmsgRelayPort, nil, nil, nil, 0, 4096, 0)
+	role := dmsgRelayRole(nil, nil, nil, 0, 4096, 0)
 
 	require.Equal(t, skyenv.DmsgRelayPort, role.Port)
 	require.Empty(t, role.RelayPeers)
@@ -154,7 +154,7 @@ func TestDmsgRelayRole_AttachedNominees(t *testing.T) {
 	unreached, _ := cipher.GenerateKeyPair()
 	server, _ := cipher.GenerateKeyPair()
 
-	role := dmsgRelayRole(skyenv.DmsgRelayPort,
+	role := dmsgRelayRole(
 		[]cipher.PubKey{hub, unreached},
 		[]dmsgSessionView{
 			{PK: hub, Carrier: "skynet", Streams: 3, LatencyMS: 42},
@@ -178,7 +178,7 @@ func TestDmsgRelayRole_RelayingForPeers(t *testing.T) {
 	a, _ := cipher.GenerateKeyPair()
 	b, _ := cipher.GenerateKeyPair()
 
-	role := dmsgRelayRole(skyenv.DmsgRelayPort, nil, nil,
+	role := dmsgRelayRole(nil, nil,
 		map[cipher.PubKey]int{a: 2, b: 5}, 7, 4096, 3)
 
 	require.Len(t, role.RelayClients, 2)
@@ -201,7 +201,7 @@ func TestDmsgRelayRole_RelayingForPeers(t *testing.T) {
 // A negative cap is the "never relay for anyone" setting, and stays visible as
 // such rather than being normalized away.
 func TestDmsgRelayRole_RefusesToRelay(t *testing.T) {
-	role := dmsgRelayRole(skyenv.DmsgRelayPort, nil, nil, nil, 0, -1, 0)
+	role := dmsgRelayRole(nil, nil, nil, 0, -1, 0)
 	require.Equal(t, -1, role.MaxRelayedStreams)
 	require.Empty(t, role.RelayClients)
 }

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -307,7 +307,7 @@ type DmsgWebConfig struct {
 	// Enable must be true for the resolver to start.
 	Enable bool `json:"enable"`
 	// SecretKey runs the resolver under its OWN dmsg identity instead of the
-	// visor's. Unset (the default) keeps today's behaviour: the resolver
+	// visor's. Unset (the default) keeps today's behavior: the resolver
 	// borrows v.dmsgC and answers as the visor.
 	//
 	// It exists because some keys cannot move. The survey whitelist knows the


### PR DESCRIPTION
All three platform lanes have been failing on every PR, and the failing step is **golangci-lint, not the tests**. The action pins `version: latest`, so a linter release can turn every lane red at once without a line of our code changing — which is what happened.

Nothing here is a behavior change:

| linter | n | what |
|---|---|---|
| misspell | 6 | `neighbours`, `cancelled`, `marshalled`, `unrecognised`, `behaviour` — comments bar one test message |
| errcheck | 7 | `_, _ = w.Write(…)` in `compress_test`; `check-blank` is on in `.golangci.yml` so blanking is not available. A handler that cannot write its body is a real test failure, so they go through a `mustWrite` helper that says so |
| gosec | 5 | G115 narrowings made explicit (masked byte truncation, bounded `uint64`→`int64` heap delta, guarded `FileInfo.Size`) and a G302 `nolint` where a `0o500` **directory** is the subject of the test |
| unparam | 2 | `mkVal`’s `n` was 8192 at all five call sites — a property of the fixture, now a named constant; `dmsgRelayRole`’s `port` was always `skyenv.DmsgRelayPort` |
| staticcheck | 1 | `DmsgRelayAttachment(s)` instead of re-listing four identical fields |

`golangci-lint run` over the whole repo is clean on this branch, and every touched package still passes its tests. Three of the misspells are mine, from the carrier-dial and cxosub work earlier today.

Note `pkg/cxo/treestore`’s bounded-retention flake (#4820) was a separate cause of the same three lanes being red; this is the other half. A darwin-only `TestUnifiedQUICWTSessions` failure is still outstanding and not addressed here.