### PR TITLE
feat(dmsg): serve the local relay acceptor by default

### DIFF
--- a/pkg/dmsg/dmsgc/spec/local_relay_test.go
+++ b/pkg/dmsg/dmsgc/spec/local_relay_test.go
@@ -26,7 +26,7 @@ func TestLocalRelay_RoundTrip(t *testing.T) {
 	if c.LocalRelay == nil {
 		t.Fatal("local_relay not parsed from JSON")
 	}
-	if !c.LocalRelay.Enabled {
+	if c.LocalRelay.Enabled == nil || !*c.LocalRelay.Enabled {
 		t.Fatal("local_relay.enabled not parsed")
 	}
 	if c.LocalRelay.Socket != "/run/skywire/relay.sock" {
@@ -58,5 +58,56 @@ func TestLocalRelay_RoundTrip(t *testing.T) {
 	}
 	if strings.Contains(string(out), "local_relay") {
 		t.Fatalf("nil local_relay should be omitted: %s", out)
+	}
+}
+
+// TestLocalRelayEnabledDefaultsOn pins the tri-state the *bool exists for.
+//
+// The acceptor used to be off unless switched on, and the switch defended
+// nothing: the socket is 0600 owned by the visor's user, and so is the config
+// holding its secret key, so anyone who can open the socket can already take
+// the key. What it did cost was a config edit and a restart on every host that
+// wanted to run a keyed service against its visor. An operator who genuinely
+// wants it off must still be able to say so, hence "unset" and "false" cannot
+// be the same value.
+func TestLocalRelayEnabledDefaultsOn(t *testing.T) {
+	enabled := func(c *DmsgLocalRelayConfig) bool {
+		// The visor's gate, verbatim (initLocalDmsgRelay).
+		return c.Enabled == nil || *c.Enabled
+	}
+
+	no, yes := false, true
+	for _, tc := range []struct {
+		name string
+		cfg  *DmsgLocalRelayConfig
+		want bool
+	}{
+		{"unset means on", &DmsgLocalRelayConfig{}, true},
+		{"explicit true stays on", &DmsgLocalRelayConfig{Enabled: &yes}, true},
+		{"explicit false is honored", &DmsgLocalRelayConfig{Enabled: &no}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := enabled(tc.cfg); got != tc.want {
+				t.Fatalf("enabled = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	// An explicit false must survive a JSON round trip — omitempty on a *bool
+	// omits nil, not false, and losing it would silently re-enable a relay an
+	// operator turned off.
+	var c DmsgConfig
+	if err := json.Unmarshal([]byte(`{"local_relay":{"enabled":false}}`), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.LocalRelay == nil || c.LocalRelay.Enabled == nil || *c.LocalRelay.Enabled {
+		t.Fatalf("explicit false not parsed: %+v", c.LocalRelay)
+	}
+	out, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), `"enabled":false`) {
+		t.Fatalf("explicit false dropped on write: %s", out)
 	}
 }

--- a/pkg/dmsg/dmsgc/spec/spec.go
+++ b/pkg/dmsg/dmsgc/spec/spec.go
@@ -163,9 +163,24 @@ type DmsgConfig struct {
 // address; the visor refuses to bind it otherwise rather than quietly opening
 // an unauthenticated path to its own transports.
 type DmsgLocalRelayConfig struct {
-	// Enabled gates the whole acceptor. False (or a nil
-	// *DmsgLocalRelayConfig) = the visor serves no local relay.
-	Enabled bool `json:"enabled"`
+	// Enabled gates the whole acceptor, and defaults to TRUE: a visor serves
+	// its unix-socket relay unless an operator turns it off.
+	//
+	// It used to default to false, and the flag was defending nothing. The
+	// socket is 0600 and owned by the visor's user, and on a packaged install
+	// so is the visor's config file — which holds the secret key. Any process
+	// that can open the socket can already read that key outright, so the
+	// acceptor grants strictly LESS than what such a process has. What the
+	// default did cost was real: every host wanting to run a keyed service
+	// against its visor (the resolving proxy under a survey-whitelist key is
+	// the motivating one) needed a config edit and a restart first.
+	//
+	// TCPAddress is the part that genuinely needs opting into, and is gated
+	// separately: it has no filesystem gate at all. Nothing here changes that.
+	//
+	// A pointer so "unset" is distinguishable from an explicit false: nil means
+	// the default, false means an operator said no.
+	Enabled *bool `json:"enabled,omitempty"`
 	// Socket is the unix socket path the acceptor listens on. Empty means
 	// "<local_path>/dmsg_relay.sock". Set it to "-" to run with no unix
 	// socket at all (TCPAddress only).

--- a/pkg/visor/init_dmsg_relay_local.go
+++ b/pkg/visor/init_dmsg_relay_local.go
@@ -84,8 +84,14 @@ func (v *Visor) initLocalDmsgRelay(ctx context.Context, dmsgC *dmsg.Client) {
 	if v.conf == nil || v.conf.Dmsg == nil {
 		return
 	}
+	// No local_relay block at all is the common case and now means "defaults":
+	// the unix socket, 0600, under the visor's local path. See
+	// DmsgLocalRelayConfig.Enabled for why this is on rather than off.
 	conf := v.conf.Dmsg.LocalRelay
-	if conf == nil || !conf.Enabled {
+	if conf == nil {
+		conf = &spec.DmsgLocalRelayConfig{}
+	}
+	if conf.Enabled != nil && !*conf.Enabled {
 		return
 	}
 	log := v.MasterLogger().PackageLogger("dmsg_relay_local")


### PR DESCRIPTION
`dmsg.local_relay.enabled` defaulted to false, and the flag was defending nothing. The acceptor is a unix socket at 0600 owned by the visor's user, and on a packaged install the visor's config — which holds its secret key — is 0600 and owned by the same user:

```
-rw------- _skywire  /opt/skywire/skywire.json
srw------- d0mo      ~/.skywire/dmsg-local-relay.sock
```

Any process that can open that socket can already read the secret key outright, so attaching grants it strictly **less** than it has. The flag was a second lock on a door the first lock already holds.

What the default did cost was real: every host wanting to run a service under its own fixed key against its visor — the resolving proxy under a survey-whitelist key, the case that motivated the feature — needed a config edit and a visor restart before it could even try.

`tcp_address` is the part that genuinely needs opting into (no filesystem gate at all, which is why it already requires a non-empty `allowed_keys` and a loopback address). Unchanged — only the socket's default moves.

`Enabled` becomes `*bool` so "unset" and "an operator said no" stay distinguishable: with `omitempty` on a `*bool`, nil is omitted and an explicit `false` is written back, so turning it off survives a config rewrite. A test covers all three states and that round trip.

**Compatibility:** `enabled:true` and `enabled:false` both keep meaning what they said. A visor with no `local_relay` block gains the socket. A host where binding fails (path over 103 chars, no AF_UNIX) logs and carries on exactly as before — this never fails visor startup.