### PR TITLE
feat(dmsg): env knobs for the local relay, so the loopback acceptor is usable

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -479,6 +479,9 @@ func init() {
 	genConfigCmd.Flags().BoolVar(&dmsgServerOwnKey, "dmsg-server", scriptExecBool("${DMSGSERVER:-false}"), "run a dmsg server inside the visor on the visor's OWN key, sharing its transport port")
 	gHiddenFlags = append(gHiddenFlags, "dmsg-server")
 	genConfigCmd.Flags().StringVar(&dmsgServerPublicAddr, "dmsg-server-public", scriptExecString("${DMSGSERVERPUBLIC}"), "address that in-visor dmsg server advertises (host:port); empty advertises whatever its listener resolves to")
+	genConfigCmd.Flags().StringVar(&dmsgRelayAddr, "dmsg-relay-addr", scriptExecString("${DMSGRELAYADDR}"), "loopback host:port for the dmsg relay acceptor, for local services that cannot use the unix socket (a different user than the visor). Requires --dmsg-relay-keys")
+	genConfigCmd.Flags().StringVar(&dmsgRelayKeys, "dmsg-relay-keys", scriptExecString("${DMSGRELAYKEYS}"), "public keys allowed to attach to the dmsg relay, comma-separated. Required with --dmsg-relay-addr: a TCP listener has no filesystem gate")
+	genConfigCmd.Flags().BoolVar(&noDmsgRelay, "no-dmsg-relay", scriptExecBool("${NODMSGRELAY:-false}"), "do not serve the local dmsg relay acceptor at all (it is served by default)")
 	gHiddenFlags = append(gHiddenFlags, "dmsg-server-public")
 
 	genConfigCmd.Flags().BoolVar(&isAll, "all", false, "show all flags")
@@ -1515,6 +1518,33 @@ func configureLauncher(log *logging.Logger) {
 			Enabled:       true,
 			PublicAddress: dmsgServerPublicAddr,
 		}
+	}
+
+	// Local dmsg relay acceptor. The unix socket is served by default and needs
+	// no config, but it is created with the VISOR's uid at 0600 — so on a
+	// packaged install (visor as root) a service running as any other user
+	// cannot open it, and socket_mode does not help because the group is the
+	// visor's. DMSGRELAYADDR gives those services a loopback TCP acceptor
+	// instead, where the gate is the key allowlist rather than file
+	// permissions. Without these knobs the block could only be hand-edited into
+	// the json, and the next autoconfig would drop it — the same trap
+	// dmsg.server hit before DMSGSERVER existed.
+	if noDmsgRelay {
+		off := false
+		conf.Dmsg.LocalRelay = &dmsgc.DmsgLocalRelayConfig{Enabled: &off}
+	} else if dmsgRelayAddr != "" || dmsgRelayKeys != "" {
+		relay := &dmsgc.DmsgLocalRelayConfig{TCPAddress: dmsgRelayAddr}
+		for _, k := range strings.FieldsFunc(dmsgRelayKeys, func(r rune) bool { return r == ',' || r == ';' || r == ' ' }) {
+			var pk cipher.PubKey
+			if err := pk.Set(k); err != nil {
+				log.Fatalf("invalid --dmsg-relay-keys entry %q: %v", k, err)
+			}
+			relay.AllowedKeys = append(relay.AllowedKeys, pk)
+		}
+		if relay.TCPAddress != "" && len(relay.AllowedKeys) == 0 {
+			log.Fatal("--dmsg-relay-addr requires --dmsg-relay-keys: a TCP acceptor has no filesystem gate")
+		}
+		conf.Dmsg.LocalRelay = relay
 	}
 
 	// Configure the skycoin-web wallet. Only emit a block when the operator

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -211,6 +211,9 @@ var (
 	dmsgServerConf       string
 	dmsgServerOwnKey     bool
 	dmsgServerPublicAddr string
+	dmsgRelayAddr        string
+	dmsgRelayKeys        string
+	noDmsgRelay          bool
 )
 
 // RootCmd contains commands that interact with the config of local skywire-visor

--- a/pkg/dmsg/dmsgc/dmsgc.go
+++ b/pkg/dmsg/dmsgc/dmsgc.go
@@ -34,6 +34,9 @@ type DmsgConfig = spec.DmsgConfig
 // DmsgServerConfig is the in-process dmsg server block (Dmsg.Server).
 type DmsgServerConfig = spec.DmsgServerConfig
 
+// DmsgLocalRelayConfig is the local relay acceptor block (Dmsg.LocalRelay).
+type DmsgLocalRelayConfig = spec.DmsgLocalRelayConfig
+
 // lanPriorityDisc wraps a disc.APIClient to prepend LAN server entries
 // to discovery results. LAN servers are tried first, with automatic
 // fallback to public servers if the LAN server is unreachable.

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -155,6 +155,18 @@ type Values struct {
 	// DMSGSERVERPUBLIC.
 	DmsgServerPublic string
 
+	// DmsgRelayAddr is a loopback host:port for the local dmsg relay acceptor —
+	// writes DMSGRELAYADDR. The unix socket is served by default and needs no
+	// config, but it carries the VISOR's uid at 0600, so a service running as a
+	// different user cannot open it. A loopback acceptor has no such problem;
+	// its gate is DmsgRelayKeys instead of file permissions.
+	DmsgRelayAddr string
+	// DmsgRelayKeys are the public keys allowed to attach, comma-separated —
+	// writes DMSGRELAYKEYS. Required with DmsgRelayAddr.
+	DmsgRelayKeys string
+	// NoDmsgRelay turns the acceptor off entirely — writes NODMSGRELAY.
+	NoDmsgRelay bool
+
 	// --- Privacy / routing knobs ---
 	MinHops            int  // MINHOPS (>=2 forces multihop for sender privacy)
 	ARTransportLimit   int  // ARTRANSPORTLIMIT (address-resolver registration policy)
@@ -325,6 +337,9 @@ func New(v *Values) *cobra.Command {
 	cmd.Flags().BoolVar(&v.DmsgServer, "dmsg-server", false, "run a dmsg server inside the visor on the VISOR's OWN key, sharing --transport-port (one identity, one discovery entry, one forwarded port). Pin --transport-port to a port reachable from outside. Ignored when --dmsg-server-conf is set — writes DMSGSERVER in skywire.conf")
 	cmd.Flags().BoolVar(&v.NoDmsgServer, "no-dmsg-server", false, "stop running a dmsg server inside the visor — writes DMSGSERVER=false in skywire.conf")
 	cmd.Flags().StringVar(&v.DmsgServerPublic, "dmsg-server-public", "", "host:port the in-visor dmsg server advertises; empty advertises whatever its listener resolves to, which is only right on a LAN — writes DMSGSERVERPUBLIC in skywire.conf")
+	cmd.Flags().StringVar(&v.DmsgRelayAddr, "dmsg-relay-addr", "", "loopback host:port for the local dmsg relay acceptor, for services that run as a different user than the visor and so cannot open its 0600 unix socket. Requires --dmsg-relay-keys — writes DMSGRELAYADDR in skywire.conf")
+	cmd.Flags().StringVar(&v.DmsgRelayKeys, "dmsg-relay-keys", "", "public keys allowed to attach to the dmsg relay, comma-separated. Required with --dmsg-relay-addr: a TCP acceptor has no filesystem gate — writes DMSGRELAYKEYS in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoDmsgRelay, "no-dmsg-relay", false, "do not serve the local dmsg relay acceptor at all (served by default) — writes NODMSGRELAY in skywire.conf")
 
 	// --- Whitelists ---
 	cmd.Flags().StringVar(&v.DmsgptyPks, "dmsgpty-pks", "", "additional dmsgpty-whitelist PKs (hypervisor PKs are already implicit) — writes DMSGPTYPKS in skywire.conf")
@@ -489,6 +504,12 @@ var envMap = map[string]EnvMapping{
 	"no-dmsg-server": {Key: "DMSGSERVER", Format: EnvFormatBool, Negate: true, Default: "false"},
 	"dmsg-server-public": {Key: "DMSGSERVERPUBLIC", Format: EnvFormatString,
 		Note: "host:port the DMSGSERVER entry advertises. Empty advertises whatever the listener resolves to, which is only right on a LAN."},
+	"dmsg-relay-addr": {Key: "DMSGRELAYADDR", Format: EnvFormatString,
+		Note: "Loopback host:port for the local dmsg relay acceptor. The unix socket is served by default but carries the VISOR's uid at 0600, so a service running as another user cannot open it; this gives those services a way in. Requires DMSGRELAYKEYS."},
+	"dmsg-relay-keys": {Key: "DMSGRELAYKEYS", Format: EnvFormatString,
+		Note: "Comma-separated public keys allowed to attach to the dmsg relay. Required with DMSGRELAYADDR — a TCP acceptor has no filesystem gate, so the key allowlist IS the gate."},
+	"no-dmsg-relay": {Key: "NODMSGRELAY", Format: EnvFormatBool, Default: "false",
+		Note: "Turns the local dmsg relay acceptor off entirely. It is served by default; a process that can open its socket could already read the visor's secret key, so the acceptor grants no more than it has."},
 
 	// Privacy / routing knobs.
 	"min-hops":             {Key: "MINHOPS", Format: EnvFormatInt, Default: "1"},

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go
@@ -22,6 +22,7 @@ var allFlags = []string{
 	"stcpr", "sudph", "transport-port", "min-hops", "ar-transport-limit",
 	"no-direct-transports", "pty-rpc-exec", "lan-dmsg-port", "lan-dmsg-public",
 	"dmsg-server-conf", "dmsg-server", "no-dmsg-server", "dmsg-server-public",
+	"dmsg-relay-addr", "dmsg-relay-keys", "no-dmsg-relay",
 	// Whitelists
 	"dmsgpty-pks", "survey", "routesetup", "tpsetup",
 	// Route calculation


### PR DESCRIPTION
The unix socket the visor serves by default carries the **visor's uid** at 0600. On a packaged install that is root, so a service running as any other user cannot open it — and `socket_mode` does not help, because the group is the visor's group. Magnetosphere is the live case: visor as root, `dmsgweb-surveys` as `d0mo`, socket `root:root 0600`.

The config already had the answer: a loopback `tcp_address` gated by `allowed_keys`, where the gate is a key allowlist rather than file permissions — arguably the stronger boundary, since it authorizes an *identity* rather than whoever happens to run as a uid. Verified end to end on a live visor:

| | result |
|---|---|
| allowlisted key, `--attach tcp://127.0.0.1:7070` | fetched TPD `/health` through the relay |
| key not in `allowed_keys` | refused |

What was missing is that `dmsg.local_relay` appears nowhere in `config gen` or `autoconfig`, so the block could only be hand-edited into the json and the next `skywire autoconfig` would drop it — exactly the trap `dmsg.server` hit before `DMSGSERVER` existed (#4792).

Adds `DMSGRELAYADDR`, `DMSGRELAYKEYS`, `NODMSGRELAY` with matching gen + autoconfig flags and envMap entries, and the flags into the coverage test's canonical list (the thing that stops this drifting again).

`--dmsg-relay-addr` without `--dmsg-relay-keys` is refused rather than quietly opening an ungated acceptor; an unparseable key is refused rather than silently dropped; generating with neither flag emits no block, so the default stays the default.