### PR TITLE
fix(dmsg): don't charge a host's own attached service to the relay budget

### DIFF
--- a/pkg/dmsg/dmsg/client_relay.go
+++ b/pkg/dmsg/dmsg/client_relay.go
@@ -74,8 +74,8 @@ func (ce *Client) sessionDialer() SessionDialer {
 	return ce.conf.SessionDialer
 }
 
-// AcceptRelaySession runs one attached peer's relay session over conn until
-// the peer hangs up, ctx is canceled, or the client closes; it blocks for the
+// AcceptRelaySession runs one REMOTE peer's relay session over conn until the
+// peer hangs up, ctx is canceled, or the client closes; it blocks for the
 // session's lifetime, so callers run it in the accept loop's goroutine. The
 // client answers the peer's Noise XK handshake as the server side, learns the
 // peer's key from it, and asks allow (if non-nil) whether to keep the peer;
@@ -86,6 +86,20 @@ func (ce *Client) sessionDialer() SessionDialer {
 //
 // conn is closed on every return.
 func (ce *Client) AcceptRelaySession(ctx context.Context, conn net.Conn, allow func(cipher.PubKey) bool) error {
+	return ce.acceptRelaySession(ctx, conn, allow, false)
+}
+
+// AcceptLocalRelaySession is AcceptRelaySession for an attach this HOST made —
+// the unix socket, the loopback listener, or the in-process pipe. Its streams
+// are not charged to the relay budget: that budget bounds what this visor
+// carries for OTHER PEOPLE, and a service the operator runs beside the visor
+// under its own key is not other people. The socket's file mode and
+// allowed_keys are that path's gate.
+func (ce *Client) AcceptLocalRelaySession(ctx context.Context, conn net.Conn, allow func(cipher.PubKey) bool) error {
+	return ce.acceptRelaySession(ctx, conn, allow, true)
+}
+
+func (ce *Client) acceptRelaySession(ctx context.Context, conn net.Conn, allow func(cipher.PubKey) bool, local bool) error {
 	ss, err := makeServerSession(metrics.NewEmpty(), &ce.EntityCommon, conn)
 	if err != nil {
 		_ = conn.Close() //nolint:errcheck
@@ -99,6 +113,7 @@ func (ce *Client) AcceptRelaySession(ctx context.Context, conn net.Conn, allow f
 		return ErrRelayPeerNotAllowed
 	}
 	ss.relayInbound = true
+	ss.relayLocal = local
 
 	ss.sm.mutx.Lock()
 	ss.sm.yamux, err = yamux.Server(conn, YamuxConfig())

--- a/pkg/dmsg/dmsg/relay_inproc.go
+++ b/pkg/dmsg/dmsg/relay_inproc.go
@@ -72,7 +72,7 @@ func (ce *Client) InProcessRelayDialer(ctx context.Context, allow func(cipher.Pu
 			// guest's dial, which returns as soon as the session handshake
 			// completes. Tying the accept side to it would tear the session
 			// down the moment it came up.
-			if err := ce.AcceptRelaySession(ctx, hostEnd, allow); err != nil {
+			if err := ce.AcceptLocalRelaySession(ctx, hostEnd, allow); err != nil {
 				ce.log.WithError(err).Debug("dmsg in-process relay session ended with error")
 			}
 			_ = hostEnd.Close() //nolint:errcheck

--- a/pkg/dmsg/dmsg/relay_inproc_test.go
+++ b/pkg/dmsg/dmsg/relay_inproc_test.go
@@ -7,6 +7,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
 )
 
 // A guest attached in-process holds exactly one session — to its host, over an
@@ -82,4 +86,59 @@ func TestAttachInProcessRejects(t *testing.T) {
 		_, err := d(ctx, CarrierSkynet, SkynetAddr(otherPK, 70))
 		require.ErrorContains(t, err, "host is")
 	})
+}
+
+// TestInProcessGuestNotChargedRelayBudget covers the case the refuse-and-fall-
+// back path does not: a guest attached to its OWN host has nowhere to fall back
+// TO.
+//
+// MaxRelayedStreams bounds what a visor carries for other people. Every attach
+// path set relayInbound identically, so a host's own in-process service — the
+// resolving proxy under a key the deployment already knows — was charged
+// against that budget too. A remote peer refused by a full or opted-out relay
+// falls back to its own server sessions (TestSkynetRelay_RefusedFallsBack...).
+// A RelayOnly+NoRegister guest holds exactly one session, to its host, and has
+// no server sessions and no discovery to fall back to: refusing it is fatal,
+// not slow. So a visor that set a cap of zero to relay for nobody silently
+// broke its own resolver.
+func TestInProcessGuestNotChargedRelayBudget(t *testing.T) {
+	hostPK, hostSK := cipher.GenerateKeyPair()
+	// Zero cap: this host relays for nobody. Its OWN guest must still work.
+	host := NewClient(hostPK, hostSK, disc.NewMock(0), &Config{MinSessions: 1})
+	host.SetLogger(logging.MustGetLogger("budget-host"))
+	defer host.Close() //nolint:errcheck
+
+	guestPK, guestSK := cipher.GenerateKeyPair()
+	guest := NewClient(guestPK, guestSK, disc.NewMock(0), &Config{
+		MinSessions: 1, RelayOnly: true, NoRegister: true,
+	})
+	guest.SetLogger(logging.MustGetLogger("budget-guest"))
+	defer guest.Close() //nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	require.NoError(t, AttachInProcess(ctx, host, guest, 70, nil))
+	go guest.Serve(ctx) //nolint:errcheck
+
+	select {
+	case <-guest.Ready():
+	case <-ctx.Done():
+		t.Fatal("guest never attached to its host")
+	}
+
+	// The host's view of the attach: present, and marked local so the budget
+	// The host stores the session after the guest's handshake completes, so the
+	// guest being Ready does not yet mean the host has registered it.
+	var ses *SessionCommon
+	require.Eventually(t, func() bool {
+		var ok bool
+		ses, ok = host.relaySession(guestPK)
+		return ok
+	}, 10*time.Second, 50*time.Millisecond, "host must hold the guest's relay session")
+
+	require.True(t, ses.relayInbound, "an attached session is always relayInbound")
+	require.True(t, ses.relayLocal, "an in-process attach is the host's OWN service, not a third party")
+	// The whole point: a zero budget refuses third parties without touching the
+	// host's own guest.
+	require.LessOrEqual(t, host.maxRelayedStreams, 0, "this host relays for nobody")
 }

--- a/pkg/dmsg/dmsg/relay_local.go
+++ b/pkg/dmsg/dmsg/relay_local.go
@@ -167,7 +167,7 @@ func (ce *Client) ServeLocalRelay(ctx context.Context, lis net.Listener, port ui
 			// Clear it again: the session that follows manages its own
 			// deadlines, and a stale write deadline would kill it mid-stream.
 			_ = conn.SetWriteDeadline(time.Time{}) //nolint:errcheck
-			if err := ce.AcceptRelaySession(ctx, conn, allow); err != nil {
+			if err := ce.AcceptLocalRelaySession(ctx, conn, allow); err != nil {
 				ce.log.WithError(err).Debug("dmsg local relay session ended with error")
 			}
 		}(conn)

--- a/pkg/dmsg/dmsg/server_session.go
+++ b/pkg/dmsg/dmsg/server_session.go
@@ -391,7 +391,7 @@ func (ss *ServerSession) bridgeStream(log logrus.FieldLogger, yStr io.ReadWriteC
 	// this server carrying traffic for someone that is not its own client.
 	// Bound the concurrent count so an always-open relay can't be amplified. A
 	// plain local client↔client bridge is normal operation and is never gated.
-	if ss.isPeer || dst.isPeer || ss.relayInbound || req.SrcAddr.PK != ss.rPK {
+	if !ss.relayLocal && (ss.isPeer || dst.isPeer || ss.relayInbound || req.SrcAddr.PK != ss.rPK) {
 		if !ss.entity.tryAcquireRelaySlot(ss.rPK) {
 			ss.m.RecordStream(metrics.DeltaFailed)
 			atomic.AddInt64(&ss.entity.relayRefused, 1)

--- a/pkg/dmsg/dmsg/session_common.go
+++ b/pkg/dmsg/dmsg/session_common.go
@@ -54,6 +54,21 @@ type SessionCommon struct {
 	// the relay slots (see bridgeStream). Never set on server entities.
 	relayInbound bool
 
+	// relayLocal narrows relayInbound to an attach this HOST made: the unix
+	// socket, the loopback listener, or the in-process pipe. Those are the
+	// operator's own services running under their own keys beside the visor —
+	// the resolving proxy under a survey-whitelist key is the motivating one —
+	// and they are gated by the socket's file mode and allowed_keys, not by the
+	// relay budget.
+	//
+	// The budget bounds OTHER PEOPLE's traffic. Charging a host's own service
+	// against it conflated the two, with two visible consequences: a visor that
+	// set a negative relay_max_streams to refuse relaying silently black-holed
+	// its OWN resolver, and at the default cap that resolver competed with
+	// strangers for the same slots and was held to the same per-peer quarter
+	// share.
+	relayLocal bool
+
 	netConn net.Conn // underlying net.Conn (TCP connection to the dmsg server)
 	// ys      *yamux.Session
 	// ss      *smux.Session


### PR DESCRIPTION
`relay_max_streams` bounds what a visor carries for **other people**. Every attach path set `relayInbound` identically, so a host's own services — the resolving proxy under a survey-whitelist key, anything attached over the unix socket or the in-process pipe — were charged against that budget too.

The consequence is worst where it is least visible. A remote peer refused by a full or opted-out relay falls back to its own server sessions — `TestSkynetRelay_RefusedFallsBackToServerSession` asserts it fails fast and recovers. A `RelayOnly`+`NoRegister` guest has nowhere to fall back **to**: one session, to its host, no server sessions, no discovery. Refusing it is fatal, not slow. So a visor that set `relay_max_streams` negative to relay for nobody silently broke its own resolver, and at the default cap that resolver competed with strangers for the same slots under the same per-peer quarter share.

Splits the accept path: `AcceptRelaySession` stays the remote entry point, `AcceptLocalRelaySession` serves the unix socket, the loopback listener and the in-process pipe, and only the remote one is charged. Those local paths already have the gate appropriate to them — the socket's file mode and `allowed_keys`.

Remote admission is unchanged. An earlier version of this also refused a remote attach when the cap was ≤ 0, on the theory that accepting and then refusing every stream made an opted-out visor a black hole its peers would prefer. That was wrong — the dialer already falls back fast, and the existing test says so, so that half was dropped.