### PR TITLE
feat(dmsg): DMSGWEBSK — run the embedded resolver under a fixed key

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -331,6 +331,7 @@ func init() {
 	// When both are enabled, the runtime auto-chains dmsgweb's
 	// upstream → skynetweb so one entry covers both TLDs.
 	genConfigCmd.Flags().BoolVar(&enableDmsgWeb, "dmsgweb", scriptExecBool("${DMSGWEB:-false}"), "enable embedded .dmsg resolving SOCKS5 proxy on 127.0.0.1:4445")
+	genConfigCmd.Flags().StringVar(&dmsgWebSecretKey, "dmsgweb-sk", scriptExecString("${DMSGWEBSK}"), "run the embedded resolver under THIS secret key instead of the visor's, attached in-process (for a key a deployment already knows, e.g. a survey whitelist)")
 	genConfigCmd.Flags().BoolVar(&enableSkynetWeb, "skynetweb", scriptExecBool("${SKYNETWEB:-false}"), "enable embedded .skynet resolving SOCKS5 proxy on 127.0.0.1:4446")
 	genConfigCmd.Flags().BoolVar(&enableSkymailBridge, "skymail-bridge", scriptExecBool("${SKYMAILBRIDGE:-false}"), "enable SMTP to skywire bridge on 127.0.0.1:1025")
 	genConfigCmd.Flags().StringVar(&dmsgWebUpstreamSOCKS, "dmsgweb-upstream", scriptExecString("${DMSGWEBUPSTREAM}"), "upstream SOCKS5 for non .dmsg traffic (empty chains to skynetweb)")
@@ -2409,6 +2410,19 @@ func configureResolvingProxies() {
 			Enable:        true,
 			UpstreamSOCKS: dmsgWebUpstreamSOCKS,
 			ProxyAddr:     dmsgWebProxyAddr,
+		}
+		// A key the deployment already knows — the survey whitelist is the
+		// motivating one — cannot rotate, so the resolver has to answer under
+		// it. Attaching in-process keeps that identity without a second full
+		// dmsg client: one session, no discovery entry. Without this knob the
+		// key could only be hand-written into the json, and the next autoconfig
+		// would drop it.
+		if dmsgWebSecretKey != "" {
+			var sk cipher.SecKey
+			if err := sk.Set(dmsgWebSecretKey); err != nil {
+				logger.WithError(err).Fatal("invalid --dmsgweb-sk")
+			}
+			conf.DmsgWeb.SecretKey = &sk
 		}
 	}
 	if enableSkynetWeb {

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -213,6 +213,7 @@ var (
 	dmsgServerPublicAddr string
 	dmsgRelayAddr        string
 	dmsgRelayKeys        string
+	dmsgWebSecretKey     string
 	noDmsgRelay          bool
 )
 

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -219,7 +219,11 @@ type Values struct {
 	DmsgwebUpstream   string // DMSGWEBUPSTREAM
 	SkynetwebUpstream string // SKYNETWEBUPSTREAM
 	DmsgwebAddr       string // DMSGWEBADDR
-	SkynetwebAddr     string // SKYNETWEBADDR
+	// DmsgwebSK runs the embedded resolver under this secret key instead of the
+	// visor's — writes DMSGWEBSK. For a key the deployment already knows and
+	// cannot rotate, such as a survey whitelist.
+	DmsgwebSK     string // DMSGWEBSK
+	SkynetwebAddr string // SKYNETWEBADDR
 
 	// --- Skychat ---
 	Skychat         bool
@@ -387,6 +391,7 @@ func New(v *Values) *cobra.Command {
 	cmd.Flags().StringVar(&v.DmsgwebUpstream, "dmsgweb-upstream", "", "upstream SOCKS5 for non-.dmsg traffic (empty chains to skynetweb) — writes DMSGWEBUPSTREAM in skywire.conf")
 	cmd.Flags().StringVar(&v.SkynetwebUpstream, "skynetweb-upstream", "", "upstream SOCKS5 for non-.skynet traffic — writes SKYNETWEBUPSTREAM in skywire.conf")
 	cmd.Flags().StringVar(&v.DmsgwebAddr, "dmsgweb-addr", "", "host the .dmsg SOCKS5 proxy binds to (empty=127.0.0.1; 0.0.0.0 or a LAN IP to serve the LAN) — writes DMSGWEBADDR in skywire.conf")
+	cmd.Flags().StringVar(&v.DmsgwebSK, "dmsgweb-sk", "", "secret key the embedded resolver answers under, instead of the visor's; attached in-process so it costs one session and no discovery entry — writes DMSGWEBSK in skywire.conf")
 	cmd.Flags().StringVar(&v.SkynetwebAddr, "skynetweb-addr", "", "host the .skynet SOCKS5 proxy binds to — writes SKYNETWEBADDR in skywire.conf")
 
 	// --- Skychat ---
@@ -558,12 +563,14 @@ var envMap = map[string]EnvMapping{
 	"proxywl":          {Key: "PROXYSERVERWL", Format: EnvFormatBashArray},
 
 	// SOCKS5 web bridges
-	"dmsgweb":            {Key: "DMSGWEB", Format: EnvFormatBool},
-	"no-dmsgweb":         {Key: "DMSGWEB", Format: EnvFormatBool, Negate: true},
-	"skynetweb":          {Key: "SKYNETWEB", Format: EnvFormatBool},
-	"no-skynetweb":       {Key: "SKYNETWEB", Format: EnvFormatBool, Negate: true},
-	"dmsgweb-upstream":   {Key: "DMSGWEBUPSTREAM", Format: EnvFormatString},
-	"dmsgweb-addr":       {Key: "DMSGWEBADDR", Format: EnvFormatString},
+	"dmsgweb":          {Key: "DMSGWEB", Format: EnvFormatBool},
+	"no-dmsgweb":       {Key: "DMSGWEB", Format: EnvFormatBool, Negate: true},
+	"skynetweb":        {Key: "SKYNETWEB", Format: EnvFormatBool},
+	"no-skynetweb":     {Key: "SKYNETWEB", Format: EnvFormatBool, Negate: true},
+	"dmsgweb-upstream": {Key: "DMSGWEBUPSTREAM", Format: EnvFormatString},
+	"dmsgweb-addr":     {Key: "DMSGWEBADDR", Format: EnvFormatString},
+	"dmsgweb-sk": {Key: "DMSGWEBSK", Format: EnvFormatString,
+		Note: "Secret key the embedded resolver answers under instead of the visor's. For a key the deployment already knows and cannot rotate (a survey whitelist). Attached in-process: one session, no discovery entry."},
 	"skynetweb-addr":     {Key: "SKYNETWEBADDR", Format: EnvFormatString},
 	"skynetweb-upstream": {Key: "SKYNETWEBUPSTREAM", Format: EnvFormatString},
 

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go
@@ -23,6 +23,7 @@ var allFlags = []string{
 	"no-direct-transports", "pty-rpc-exec", "lan-dmsg-port", "lan-dmsg-public",
 	"dmsg-server-conf", "dmsg-server", "no-dmsg-server", "dmsg-server-public",
 	"dmsg-relay-addr", "dmsg-relay-keys", "no-dmsg-relay",
+	"dmsgweb-sk",
 	// Whitelists
 	"dmsgpty-pks", "survey", "routesetup", "tpsetup",
 	// Route calculation


### PR DESCRIPTION
`dmsg_web.secret_key` runs the visor's resolving proxy under its own identity, attached in-process: one session, no discovery entry, and a key the deployment already knows keeps working. It shipped with no way to set it from the environment, so it could only be hand-written into the json and the next `autoconfig` would drop it — the same trap `dmsg.server` hit before `DMSGSERVER` and `dmsg.local_relay` hit before `DMSGRELAYADDR`.

The case is magnetosphere's survey proxy, which today runs `skywire dmsg web` as a separate unit holding **eight** dmsg sessions of its own. The embedded resolver replaces that with one attached session and gains `.skynet` as well — one proxy entry point serves both faces, because dmsgweb auto-chains to skynetweb. Measured against the same destination through the same listener:

| face | result |
|---|---|
| `.dmsg` | 200 in 595 ms |
| `.skynet` | 200 in 4.4 ms |

Adds `--dmsgweb-sk` / `DMSGWEBSK` with the autoconfig flag and envMap entry, plus the flag in the coverage test's canonical list. An unparseable key is refused rather than silently dropped.