### PR TITLE
feat(dmsg): let a relay deliver over a terminal skynet leg to the destination

### DIFF
--- a/pkg/dmsg/dmsg/client_relay.go
+++ b/pkg/dmsg/dmsg/client_relay.go
@@ -210,6 +210,26 @@ func (ce *Client) closeRelaySessions() {
 // uses for its own dials. Sessions that are themselves relay attachments
 // (skynet carrier) are skipped: a relay does not chain through a relay.
 func (ce *Client) relayForwardSessions(dst cipher.PubKey) []*SessionCommon {
+	// Terminal leg first: a relay attachment whose remote IS dst delivers
+	// straight there, and nothing beats the destination itself. It has to be
+	// added explicitly because sortedMeshSessions drops skynet-carrier sessions
+	// — correctly, since for this client's OWN dials they are DialStream's
+	// phase 0 rather than a mesh path, and that helper is shared with it.
+	//
+	// This is the one case that is not chaining: the next hop is the
+	// destination, so the far end can only deliver locally or fail. Without it
+	// an attached guest's reach is "peers already attached to this relay"
+	// rather than "peers this relay can reach over skynet" — on a live hub, 2
+	// versus 504.
+	if ses, ok := ce.session(dst); ok && ses.carrier == CarrierSkynet {
+		return append([]*SessionCommon{ses}, ce.relayForwardMesh(dst)...)
+	}
+	return ce.relayForwardMesh(dst)
+}
+
+// relayForwardMesh is relayForwardSessions' ordinary path: server sessions
+// only, ordered for dst.
+func (ce *Client) relayForwardMesh(dst cipher.PubKey) []*SessionCommon {
 	var delegated []cipher.PubKey
 	ctx, cancel := context.WithTimeout(context.Background(), relayEntryLookupTimeout)
 	defer cancel()

--- a/pkg/dmsg/dmsg/relay_nominee_test.go
+++ b/pkg/dmsg/dmsg/relay_nominee_test.go
@@ -393,3 +393,47 @@ func TestRelayNominee_RelayOnlyClientHoldsRelayOnly(t *testing.T) {
 	_, err := env.dc.Entry(context.Background(), pk)
 	require.Error(t, err, "a relay-only client on its relay has no discovery entry")
 }
+
+// TestRelayForwardSessions_TerminalSkynetLegToDestination pins the one
+// exception to "a relay does not chain through a relay".
+//
+// Forwarding an attached guest's request over a session that is itself a relay
+// attachment chains relays: unbounded path, no loop prevention, far end free to
+// forward again. So skynet-carrier sessions are skipped — unless the session's
+// remote IS the destination, where the next hop is the end of the line and the
+// far end can only deliver locally or fail.
+//
+// Without the exception a guest's reach is "peers already attached to this
+// relay"; with it, "peers this relay can reach over skynet". On a live hub
+// those were 2 and 504.
+func TestRelayForwardSessions_TerminalSkynetLegToDestination(t *testing.T) {
+	env := newRelayedTestEnv(t, nil)
+	// The serve loop may redial and replace a session, which resets its
+	// carrier — so mark it immediately before each check rather than once up
+	// front, and re-fetch rather than holding a pointer across assertions.
+	asSkynet := func() {
+		ses, ok := env.relay.session(env.srvPK)
+		require.True(t, ok, "the relay holds a session to the destination's server")
+		ses.carrier = CarrierSkynet
+	}
+
+	offersSrv := func(dst cipher.PubKey) bool {
+		for _, s := range env.relay.relayForwardSessions(dst) {
+			if s.RemotePK() == env.srvPK {
+				return true
+			}
+		}
+		return false
+	}
+
+	// A relay attachment must not carry someone else's request onward.
+	asSkynet()
+	require.False(t, offersSrv(env.dstPK),
+		"a relay attachment must not carry a relayed request onward — that is chaining")
+
+	// But it is exactly the right leg when the destination is its own remote:
+	// terminal delivery, nothing further to forward.
+	asSkynet()
+	require.True(t, offersSrv(env.srvPK),
+		"a relay attachment whose remote IS the destination must be offered — terminal, not a chain")
+}


### PR DESCRIPTION
A relay skips its skynet-carrier sessions when forwarding an attached guest's request, because forwarding over one would chain a relay through a relay — unbounded path, no loop prevention, far end free to forward again. Right in general, and wrong for exactly one case: when that session's remote **is** the destination. There the next hop is the end of the line, so the far end delivers locally or fails. Nothing to chain, no loop to prevent.

What it costs today is reach. A guest attached to a well-connected visor reaches the peers already attached to that relay, not the peers that relay can get to. Measured on a live hub: **2 relay clients against 504 transports.**

That matters because the survey and pprof surfaces are gated on the **caller's** key, and only dmsg carries the caller's key end to end — the stream request is signed and `StreamRequest.Verify` checks it against `SrcAddr.PK`, while the skynet mirror of the same surface reports the routing visor instead. So a survey-whitelist proxy must reach visors over dmsg, including visors holding no dmsg server session at all but reachable over skynet from its host.

The leg is added explicitly rather than by relaxing `sortedMeshSessions`, which drops skynet-carrier sessions *correctly* — for the client's own dials they are `DialStream`'s phase 0, not a mesh path, and that helper is shared with it.

Test asserts both halves of the rule (offered when the remote is the destination, not offered otherwise) and fails without the change.