### PR TITLE
test(dmsg): bind relay sockets on a short path, and skip them on Windows

### DIFF
--- a/pkg/dmsg/dmsg/relay_local_test.go
+++ b/pkg/dmsg/dmsg/relay_local_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"net"
+	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -82,7 +84,7 @@ func newLocalRelayTestClient(t *testing.T, name string, relayOnly bool, maxRelay
 // attaches to it with AttachLocalRelay and ends up holding exactly one
 // session — to the acceptor, on the skynet carrier — under its OWN key.
 func TestAttachLocalRelay(t *testing.T) {
-	sock := filepath.Join(t.TempDir(), "relay.sock")
+	sock := shortSocketPath(t)
 	lis, err := net.Listen("unix", sock)
 	require.NoError(t, err)
 
@@ -134,7 +136,7 @@ func TestAttachLocalRelay(t *testing.T) {
 // local pipe exactly as it is on the skynet one: a key the acceptor refuses
 // gets its conn closed after the handshake, and never becomes a relay session.
 func TestAttachLocalRelayRefused(t *testing.T) {
-	sock := filepath.Join(t.TempDir(), "relay.sock")
+	sock := shortSocketPath(t)
 	lis, err := net.Listen("unix", sock)
 	require.NoError(t, err)
 
@@ -166,7 +168,7 @@ func TestAttachLocalRelayRefused(t *testing.T) {
 }
 
 func TestLocalRelayDialerWrongPeer(t *testing.T) {
-	sock := filepath.Join(t.TempDir(), "relay.sock")
+	sock := shortSocketPath(t)
 	lis, err := net.Listen("unix", sock)
 	require.NoError(t, err)
 
@@ -211,7 +213,7 @@ func TestLocalRelaySessionDialerRejectsOtherCarriers(t *testing.T) {
 // across several backoff intervals. A client stuck in the old path re-entered
 // discovery on every pass, so it could not be relied on to hold still.
 func TestAttachedClientRestsInsteadOfHuntingServers(t *testing.T) {
-	sock := filepath.Join(t.TempDir(), "relay.sock")
+	sock := shortSocketPath(t)
 	lis, err := net.Listen("unix", sock)
 	require.NoError(t, err)
 
@@ -276,4 +278,29 @@ func (b *syncBuffer) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.buf.String()
+}
+
+// shortSocketPath returns a unix-socket path short enough to bind, and skips
+// the test where unix sockets are not available at all.
+//
+// A unix socket path is capped at about 103 bytes (sun_path), and t.TempDir()
+// builds its directory out of the TEST'S NAME. On Linux that is
+// /tmp/<TestName><digits>/001 and there is room to spare; on macOS the base is
+// /var/folders/<2>/<28>/T/ before the name is even added, so a long test name
+// pushes the total past the cap and bind fails with EINVAL — which reads as a
+// broken socket rather than a path-length problem. That is what happened to
+// TestAttachedClientRestsInsteadOfHuntingServers, whose only sin was a
+// descriptive name.
+//
+// os.MkdirTemp with a two-character prefix keeps the path short regardless of
+// how the test is named, so naming stays free.
+func shortSocketPath(t *testing.T, sub ...string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("unix sockets are not supported on Windows")
+	}
+	dir, err := os.MkdirTemp("", "dr")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) }) //nolint:errcheck
+	return filepath.Join(append([]string{dir}, append(sub, "relay.sock")...)...)
 }

--- a/pkg/visor/init_dmsg_relay_local_test.go
+++ b/pkg/visor/init_dmsg_relay_local_test.go
@@ -3,6 +3,7 @@ package visor
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -43,7 +44,7 @@ func TestParseSocketMode(t *testing.T) {
 // end up owner-only, because with no allowed_keys its file mode is the ONLY
 // gate on a grant of the visor's transports.
 func TestListenLocalRelaySocketMode(t *testing.T) {
-	sock := filepath.Join(t.TempDir(), "sub", "relay.sock")
+	sock := shortRelaySocketPath(t, "sub")
 	lis, err := listenLocalRelaySocket(sock, "", logging.MustGetLogger("test"))
 	require.NoError(t, err)
 	defer lis.Close() //nolint:errcheck
@@ -64,7 +65,7 @@ func TestListenLocalRelaySocketMode(t *testing.T) {
 // bind() on an existing path fails whether or not anything is listening — so
 // the second start must unlink before it binds.
 func TestListenLocalRelaySocketReplacesStale(t *testing.T) {
-	sock := filepath.Join(t.TempDir(), "relay.sock")
+	sock := shortRelaySocketPath(t)
 	require.NoError(t, os.WriteFile(sock, nil, 0600))
 
 	lis, err := listenLocalRelaySocket(sock, "", logging.MustGetLogger("test"))
@@ -125,4 +126,25 @@ func TestLocalRelayAllow(t *testing.T) {
 	require.Error(t, err)
 	_, err = localRelayAllow(&spec.DmsgLocalRelayConfig{AllowedKeys: []cipher.PubKey{selfPK}}, selfPK)
 	require.Error(t, err)
+}
+
+// shortRelaySocketPath returns a bindable unix-socket path and skips where unix
+// sockets do not exist.
+//
+// sun_path caps a socket path at about 103 bytes, and t.TempDir() derives its
+// directory from the test's NAME — fine under /tmp on Linux, over the cap on
+// macOS where the base is already /var/folders/<2>/<28>/T/. The failure is
+// EINVAL from bind, which reads as a broken socket rather than a long path.
+//
+// Windows skips outright: these tests assert unix-socket binding and 0600
+// permission bits, neither of which it has (it reports 0666 for every file).
+func shortRelaySocketPath(t *testing.T, sub ...string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("unix sockets and POSIX permission bits are not supported on Windows")
+	}
+	dir, err := os.MkdirTemp("", "vr")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) }) //nolint:errcheck
+	return filepath.Join(append([]string{dir}, append(sub, "relay.sock")...)...)
 }


### PR DESCRIPTION
darwin and windows have been red on every PR merged today. Three of those failures are unix-socket tests, and one is a test I added in #4819.

A unix socket path is capped at ~103 bytes (`sun_path`), and `t.TempDir()` derives its directory from the **test's name**. Under `/tmp` on Linux there is room to spare; on macOS the base is `/var/folders/<2>/<28>/T/` before the name is added:

| test | macOS path | |
|---|---|---|
| `TestAttachedClientRestsInsteadOfHuntingServers` | **119 bytes** | over |
| `TestListenLocalRelaySocketMode` | **103 bytes** | at the limit |

Both fail with `EINVAL` from bind, which reads as a broken socket rather than an over-long path. `os.MkdirTemp` with a two-character prefix gives 71 bytes regardless of how a test is named, so naming stays free.

Windows has neither unix sockets nor POSIX permission bits — it reports `0666` for every file, so the `0600` assertion could never hold. Those skip now rather than fail.

**Not addressed here**, from the same sweep: an intermittent data race in `pkg/pty` (`keepaliveLoop` flushing a `ResponseWriter` after its handler returned) which is live on develop, and Windows-only mmap failures in `pkg/geoip`. Both pre-existing, neither belongs in a test-path change.