### PR TITLE
fix(pty): join the exec-stream keepalive before the handler returns

### DIFF
--- a/pkg/pty/exec_http.go
+++ b/pkg/pty/exec_http.go
@@ -504,8 +504,22 @@ func execStreamHandler(hostCtx context.Context, log *logging.Logger) http.Handle
 
 		if framed {
 			stopKA := make(chan struct{})
-			defer close(stopKA)
-			go keepaliveLoop(stopKA, &mu, w, flusher, cancel)
+			kaDone := make(chan struct{})
+			go func() {
+				defer close(kaDone)
+				keepaliveLoop(stopKA, &mu, w, flusher, cancel)
+			}()
+			// Signalling the loop is not enough, it has to be JOINED. A
+			// ResponseWriter is only valid for the lifetime of the handler:
+			// the moment this function returns, net/http's finishRequest
+			// flushes the very bufio.Writer the keepalive flushes, with no
+			// happens-before edge between the two. A loop already past its
+			// select — blocked on mu, or mid-write — would then flush after
+			// the handler is gone. Waiting on kaDone closes that window.
+			defer func() {
+				close(stopKA)
+				<-kaDone
+			}()
 		}
 
 		runErr := cmd.Run()


### PR DESCRIPTION
`keepaliveLoop` was spawned from `execStreamHandler` and only *signalled* to stop, never joined. A `ResponseWriter` is valid solely for the lifetime of its handler: the moment the handler returns, net/http's `finishRequest` flushes the same `bufio.Writer` the keepalive flushes, and closing the stop channel creates no happens-before edge back into the handler. A loop already past its select — blocked on `mu`, or mid-write — therefore flushed after the handler was gone. That is the intermittent `linux` lane failure in `TestExecStreamTimeoutIsReported`:

```
Read at 0x00c000098ee8 by goroutine 61:
  bufio.(*Writer).Flush / net/http.(*response).finishRequest
Previous write by goroutine 64 (finished):
  bufio.(*Writer).Flush / net/http.(*response).Flush
  pkg/pty.keepaliveLoop()  pkg/pty/exec_http.go:542
```

The fix waits on a done channel closed by the keepalive goroutine, so no flush can outlive the handler. The keepalive is otherwise untouched — it is load-bearing for long silent commands over dmsg, and writes were already serialised with the command's output under `mu`.

At the shipped 5s interval the race needs a framed handler to live past one tick, which no test in the package does, so it does not reproduce locally at `-count=20`. Temporarily setting `execStreamKeepalive` to 1ms reproduces the identical two stacks on every run before the change and none after. `go test ./pkg/pty/ -race -count=3` and `-run TestExecStreamTimeoutIsReported -race -count=20` are clean.