### PR TITLE
fix(lint): Signalling -> Signaling in the pty keepalive comment

### DIFF
--- a/pkg/pty/exec_http.go
+++ b/pkg/pty/exec_http.go
@@ -509,7 +509,7 @@ func execStreamHandler(hostCtx context.Context, log *logging.Logger) http.Handle
 				defer close(kaDone)
 				keepaliveLoop(stopKA, &mu, w, flusher, cancel)
 			}()
-			// Signalling the loop is not enough, it has to be JOINED. A
+			// Signaling the loop is not enough, it has to be JOINED. A
 			// ResponseWriter is only valid for the lifetime of the handler:
 			// the moment this function returns, net/http's finishRequest
 			// flushes the very bufio.Writer the keepalive flushes, with no


### PR DESCRIPTION
One word. `golangci-lint` runs `misspell` with `locale: US`, so a British spelling fails the linux, darwin and windows lanes at once.

#4831 landed without a lint pass — `golangci-lint` had been cleared off the machine along with the rest of `~/go/bin` when the disk filled, so the check could not run. Re-installed and re-run: `pkg/pty` is clean with this.