### PR TITLE
fix(dmsg): a folded dmsg server serves no wss — browsers lost 7 of 9 servers

### DIFF
--- a/pkg/dmsg/dmsg/relay_local_test.go
+++ b/pkg/dmsg/dmsg/relay_local_test.go
@@ -294,7 +294,7 @@ func (b *syncBuffer) String() string {
 //
 // os.MkdirTemp with a two-character prefix keeps the path short regardless of
 // how the test is named, so naming stays free.
-func shortSocketPath(t *testing.T, sub ...string) string {
+func shortSocketPath(t *testing.T) string {
 	t.Helper()
 	if runtime.GOOS == "windows" {
 		t.Skip("unix sockets are not supported on Windows")
@@ -302,5 +302,5 @@ func shortSocketPath(t *testing.T, sub ...string) string {
 	dir, err := os.MkdirTemp("", "dr")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.RemoveAll(dir) }) //nolint:errcheck
-	return filepath.Join(append([]string{dir}, append(sub, "relay.sock")...)...)
+	return filepath.Join(dir, "relay.sock")
 }

--- a/pkg/dmsg/dmsg/ws_server.go
+++ b/pkg/dmsg/dmsg/ws_server.go
@@ -83,3 +83,18 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 	}
 	s.handleSession(conn)
 }
+
+// WSHandler returns the dmsg-over-WebSocket handler and records advertisedWSURL
+// as this server's AddressWS, without binding a listener of its own.
+//
+// ServeWS owns a port. A dmsg server folded into a visor does not have one: it
+// shares the visor's transport port, whose HTTP/1 branch already belongs to the
+// WS transport. This lets that branch route the dmsg path here instead, so one
+// port keeps carrying raw dmsg, stcpr, WS transports AND dmsg-over-WS — which
+// is what the standalone server did on its own main port before the fold, and
+// what a browser visor needs to reach this server at all.
+func (s *Server) WSHandler(advertisedWSURL string) http.Handler {
+	s.setAdvertisedWSAddr(advertisedWSURL)
+	s.log.WithField("addr_ws", advertisedWSURL).Info("Serving dmsg over WebSocket on the shared transport port.")
+	return http.HandlerFunc(s.handleWS)
+}

--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
@@ -110,6 +111,10 @@ type ClientFactory struct {
 	// WS case in MakeClient (untagged) can read wsSharedListener directly.
 	stcprSharedListener net.Listener
 	wsSharedListener    net.Listener
+	// dmsgWSHandler routes the dmsg-over-WebSocket path on the shared transport
+	// port. Held here rather than on the WS client because the client is built
+	// per MakeClient call while the co-resident dmsg server is wired once, later.
+	dmsgWSHandler atomic.Value
 	// dmsgSharedListener is the tcpDemux branch carrying dmsg sessions, set
 	// only when ShareTCPWithDmsgServer was true at bind time.
 	dmsgSharedListener net.Listener
@@ -156,6 +161,7 @@ func (f *ClientFactory) MakeClient(netType types.Type, port int) (Client, error)
 		wc.(*wsClient).ar = f.ARClient // native: resolve ws:// from the stcpr AR record
 		if f.wsSharedListener != nil { // unified transport port
 			wc.(*wsClient).sharedListener = f.wsSharedListener
+			wc.(*wsClient).dmsgWS = &f.dmsgWSHandler
 		}
 		return wc, nil
 	case types.WT:

--- a/pkg/transport/network/client_unified_tcp.go
+++ b/pkg/transport/network/client_unified_tcp.go
@@ -88,3 +88,15 @@ func (f *ClientFactory) stcprSharedListenerFor(perTypePort int) net.Listener {
 // server that advertises what its listener resolves to advertises the shared
 // transport port.
 func (f *ClientFactory) DmsgSharedListener() net.Listener { return f.dmsgSharedListener }
+
+// SetDmsgWSHandler routes the dmsg-over-WebSocket path on the shared transport
+// port to h (an http.Handler), so a dmsg server folded into this visor keeps a
+// WS front. Typed `any` to keep net/http out of this file's import graph, as
+// ARClient is. Called once the co-resident server is up; the WS client reads it
+// per request, so ordering does not matter.
+func (f *ClientFactory) SetDmsgWSHandler(h any) {
+	if f == nil || h == nil {
+		return
+	}
+	f.dmsgWSHandler.Store(h)
+}

--- a/pkg/transport/network/ws.go
+++ b/pkg/transport/network/ws.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"sync/atomic"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/transport/network/stcp"
@@ -27,6 +28,11 @@ import (
 // wsClient is the WS-transport implementation of Client. table maps a peer PK to
 // its wss:// (or ws://) URL.
 type wsClient struct {
+	// dmsgWS routes the dmsg-over-WebSocket path on the shared transport port.
+	// An *atomic.Value holding an http.Handler, typed loosely for the same reason
+	// sharedListener is a net.Listener: this file is untagged and must not pull
+	// net/http into the TinyGo graph. Only ws_native.go loads it.
+	dmsgWS *atomic.Value
 	*genericClient
 	table stcp.PKTable
 	// sharedListener, when set, is the TCP listener the WS HTTP server serves over

--- a/pkg/transport/network/ws_native.go
+++ b/pkg/transport/network/ws_native.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/coder/websocket"
@@ -71,7 +72,7 @@ func (c *wsClient) serve() {
 	if c.sharedListener != nil {
 		// Unified transport port: run the WS HTTP server over the shared listener's
 		// HTTP virtual listener instead of binding our own.
-		lis = newWSListenerOver(c.sharedListener)
+		lis = newWSListenerOver(c.sharedListener, c.dmsgWS)
 	} else {
 		var err error
 		lis, err = newWSListener(c.listenAddr)
@@ -114,11 +115,16 @@ func (c *wsClient) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // wsListener fronts a WebSocket HTTP server as a net.Listener: each upgraded
 // WebSocket connection is delivered as a net.Conn from Accept().
 type wsListener struct {
-	addr  net.Addr
-	conns chan net.Conn
-	done  chan struct{}
-	srv   *http.Server
-	once  sync.Once
+	addr   net.Addr
+	conns  chan net.Conn
+	done   chan struct{}
+	srv    *http.Server
+	once   sync.Once
+	dmsgWS *atomic.Value
+	// dmsgWS, when set, answers the dmsg-over-WebSocket path on this same
+	// branch. Set late: the WS transport's listener comes up during transport
+	// init, the co-resident dmsg server only later, so the mux consults this at
+	// request time rather than capturing a handler at construction.
 }
 
 func newWSListener(addr string) (*wsListener, error) {
@@ -126,20 +132,35 @@ func newWSListener(addr string) (*wsListener, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newWSListenerOver(tcpLis), nil
+	return newWSListenerOver(tcpLis, nil), nil
 }
 
 // newWSListenerOver runs the WebSocket HTTP server over an already-bound TCP
 // listener (e.g. the HTTP virtual listener of a unified transport_port demux),
 // rather than binding its own.
-func newWSListenerOver(tcpLis net.Listener) *wsListener {
+func newWSListenerOver(tcpLis net.Listener, dmsgWS *atomic.Value) *wsListener {
 	l := &wsListener{
-		addr:  tcpLis.Addr(),
-		conns: make(chan net.Conn),
-		done:  make(chan struct{}),
+		addr:   tcpLis.Addr(),
+		conns:  make(chan net.Conn),
+		done:   make(chan struct{}),
+		dmsgWS: dmsgWS,
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", l.handle)
+	// The dmsg path is registered unconditionally and resolved at request time:
+	// a visor with no co-resident dmsg server answers 404 here, exactly as it
+	// did when this branch was the WS transport's alone.
+	mux.HandleFunc("/dmsg", func(w http.ResponseWriter, r *http.Request) {
+		if l.dmsgWS == nil {
+			http.NotFound(w, r)
+			return
+		}
+		if h, ok := l.dmsgWS.Load().(http.Handler); ok && h != nil {
+			h.ServeHTTP(w, r)
+			return
+		}
+		http.NotFound(w, r)
+	})
 	l.srv = &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
 	go l.srv.Serve(tcpLis) //nolint:errcheck
 	return l

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -1126,6 +1127,29 @@ func initDmsgServer(ctx context.Context, v *Visor, log *logging.Logger) error {
 		WithField("shared_transport_port", shared).
 		Info("Started in-process dmsg server on the visor key")
 
+	// Restore the WebSocket front. A standalone dmsg server served
+	// dmsg-over-WS on its own main port and advertised
+	// wss://<DNSLabel>.<suffix>/dmsg, which is the ONLY way a browser or wasm
+	// visor can reach it. Folded into a visor the server shares the transport
+	// port, whose HTTP/1 cmux branch belongs to the WS transport — so the WS
+	// front silently disappeared from every folded server, and browser visors
+	// were left with just the hosts that had never been folded.
+	//
+	// The port is unchanged by the fold (transport_port is pinned to the port
+	// the server already used), so the existing DNS record and TLS front still
+	// point at the right place. Only the routing was missing.
+	if shared && v.dmsgWSFactory != nil {
+		suffix := strings.TrimPrefix(deployment.Prod.WSSDomainSuffix, ".")
+		// Gate on the deployment knowing this key, exactly as the standalone
+		// service does: a third party running this binary must never advertise
+		// the deployment's domain for a PK with no DNS record.
+		if suffix != "" && deployment.Prod.IsKnownDmsgServer(v.conf.PK) {
+			wssURL := "wss://" + v.conf.PK.DNSLabel() + "." + suffix + "/dmsg"
+			v.dmsgWSFactory.SetDmsgWSHandler(srv.WSHandler(wssURL))
+			log.WithField("ws_url", wssURL).
+				Info("Serving dmsg over WebSocket on the shared transport port")
+		}
+	}
 	v.dmsgSrv.Store(srv)
 	v.dmsgSrvRole.Store(&DmsgServerRole{
 		Mode:                dmsgServerModeOwnKey,

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -643,6 +643,7 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 	}
 	if lis := factory.DmsgSharedListener(); lis != nil {
 		v.dmsgSharedLis = lis
+		v.dmsgWSFactory = &factory
 		log.WithField("addr", lis.Addr()).
 			Info("In-process dmsg server will share the visor's transport TCP port")
 	}

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -144,6 +144,10 @@ type Visor struct {
 	// handed to the in-process dmsg server so it shares the visor's TCP port.
 	// nil when the server is off, keyed separately, or pinned to its own address.
 	dmsgSharedLis net.Listener
+	// dmsgWSFactory is the transport ClientFactory, kept so the co-resident dmsg
+	// server can register its WebSocket handler on the shared port once it is up
+	// (see initDmsgServer). Only set when the port is actually shared.
+	dmsgWSFactory interface{ SetDmsgWSHandler(any) }
 	// dmsgSrvRole records the in-process dmsg server that actually started
 	// (nil = none), so `visor state --select roles` can report the running
 	// server's key and address rather than only what the config asked for.


### PR DESCRIPTION
`cli mdisc check` says 2 of 9 dmsg servers have a working wss front, and the two that work are exactly the two never folded onto a visor key. Six folded ones advertise no `AddressWS` at all; the seventh advertises one that refuses on :443.

A standalone dmsg server serves dmsg-over-WS on its main port and advertises `wss://<DNSLabel>.<suffix>/dmsg` — the only way a browser or wasm visor reaches it. Folded into a visor it shares the transport port, whose HTTP/1 cmux branch already belongs to the WS transport, so the WS front silently vanished; `DmsgServerConfig` cannot even express one. The port is unchanged by the fold, so DNS and the TLS front still point at the right place — verified every current key’s `DNSLabel` resolves to its own host, and all are in the embedded deployment config so the suffix gate passes. Only the routing was missing.

So route by path on the branch that already exists: `/dmsg` to the dmsg server, everything else to the WS transport — the same shape the hypervisor UI port uses to mount WS transports at `/tp/ws`. Adds `Server.WSHandler` (ServeWS without owning a listener) plus a late-settable handler, since the WS listener comes up during transport init and the dmsg server only later. Typed `any` through `ws.go`/`client.go` because those are untagged and must not pull `net/http` into the TinyGo graph; js/wasm builds and that graph is unchanged from develop.

Deployment still needs the TLS front restored on the host whose :443 refuses.