### PR TITLE
fix(dmsg): one dial per server, so a pinned rendezvous cannot evict a live session

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -286,6 +286,14 @@ type Client struct {
 	lostSession   map[cipher.PubKey]int
 	lostSessionMx sync.Mutex
 
+	// dialFlight coalesces concurrent session establishment per dmsg-server
+	// PK: at most ONE dial to a given server is in flight, and everyone else
+	// waiting on it gets that dial's result. See dialSessionOnce for why a
+	// duplicate dial is destructive rather than merely wasteful. Lazily
+	// initialized; guarded by dialFlightMx.
+	dialFlight   map[cipher.PubKey]*sessionDialFlight
+	dialFlightMx sync.Mutex
+
 	// carrier convergence controls: convMx guards a runtime override of the
 	// ordered carrier preference (nil = Config.Carriers) and a live-only
 	// discovery client used to read a server's CURRENT WT/QUIC endpoints

--- a/pkg/dmsg/dmsg/client_dialflight_test.go
+++ b/pkg/dmsg/dmsg/client_dialflight_test.go
@@ -1,0 +1,87 @@
+// Package dmsg pkg/dmsg/dmsg/client_dialflight_test.go c1-net-dmsg
+package dmsg
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// Concurrent EnsureAndObtainSession calls for one server must produce ONE
+// session, not one per caller.
+//
+// A dmsg server keeps a single session per client PK, and both ends install a
+// reconnect newest-session-wins, so every duplicate dial EVICTS the session the
+// previous caller was handed — at the server (which closes it remotely) and in
+// the client's own map. The callers that raced hold dead sessions, their streams
+// die, and the Serve loop re-dials a server it never lost.
+//
+// The pinned-rendezvous hostname in pkg/dmsgweb (<server-pk>.<dest-pk>.dmsg) is
+// how a user reaches this from a browser: one page opens several connections,
+// each one dials the named server, and a hostname anyone can type costs a live
+// session. Before the coalescing in dialSessionOnce, six concurrent callers got
+// six distinct sessions and five of them were dead on arrival.
+func TestEnsureAndObtainSession_CoalescesConcurrentDials(t *testing.T) {
+	dc := disc.NewMock(0)
+	srvPK, srvSK := GenKeyPair(t, "dialflight-srv")
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := lis.Addr().String()
+
+	srv := NewServer(srvPK, srvSK, dc, &ServerConfig{MaxSessions: 20, UpdateInterval: 0}, nil)
+	srv.SetLogger(logging.MustGetLogger("dialflight-srv"))
+	entry := disc.NewServerEntry(srvPK, 0, addr, 20)
+	require.NoError(t, entry.Sign(srvSK))
+	require.NoError(t, dc.PostEntry(context.Background(), entry))
+	go func() { _ = srv.Serve(lis, addr) }() //nolint:errcheck
+	t.Cleanup(func() { _ = srv.Close() })    //nolint:errcheck
+
+	// No Serve loop: the pinned dials below are the only dials, so the race is
+	// the one under test rather than one with the client's own reconnect loop.
+	pk, sk := GenKeyPair(t, "dialflight-cli")
+	c := NewClient(pk, sk, dc, &Config{MinSessions: 1})
+	c.SetLogger(logging.MustGetLogger("dialflight-cli"))
+	t.Cleanup(func() { _ = c.Close() }) //nolint:errcheck
+
+	const callers = 6
+	var (
+		wg    sync.WaitGroup
+		start = make(chan struct{})
+		got   = make([]ClientSession, callers)
+		errs  = make([]error, callers)
+	)
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			got[i], errs[i] = c.EnsureAndObtainSession(context.Background(), srvPK)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	distinct := make(map[*SessionCommon]struct{}, callers)
+	for i := 0; i < callers; i++ {
+		require.NoError(t, errs[i], "caller %d", i)
+		distinct[got[i].SessionCommon] = struct{}{}
+	}
+	require.Len(t, distinct, 1, "concurrent callers dialed duplicate sessions to one server")
+
+	// Give any duplicate's eviction time to land, then check that the session
+	// the first caller was handed is still the live one.
+	time.Sleep(500 * time.Millisecond)
+	live, ok := c.Session(srvPK)
+	require.True(t, ok, "the client lost its session to the server")
+	require.Same(t, got[0].SessionCommon, live.SessionCommon,
+		"the session handed to the first caller was replaced and closed")
+	require.Equal(t, 1, c.SessionCount())
+}

--- a/pkg/dmsg/dmsg/client_sessions.go
+++ b/pkg/dmsg/dmsg/client_sessions.go
@@ -25,9 +25,10 @@ import (
 // ce.dc may be a dmsgfirst-wrapped client whose primary path dials over
 // DMSG itself — DialStream → phase 3 → EnsureAndObtainSession on the
 // same goroutine, which would re-acquire sesMx and self-deadlock on a
-// non-reentrant mutex. Holding the lock only during the cache check and
-// the dialSession step still serializes concurrent dials to the same
-// server, preserving the invariant the lock was protecting.
+// non-reentrant mutex. It is released across the dial too, for the same
+// reason; what serializes concurrent dials to one server is not sesMx but
+// dialSessionOnce, which is where the reason they must be serialized is
+// written down.
 //
 // We also resolve the server entry from the local entryCache first when
 // possible. If we go to ce.dc here, the dmsgfirst wrapper's primary
@@ -70,9 +71,92 @@ func (ce *Client) EnsureAndObtainSession(ctx context.Context, srvPK cipher.PubKe
 	// EnsureAndObtainSession through this same client. Holding sesMx here
 	// would re-lock this non-reentrant mutex on the same goroutine and
 	// deadlock the whole dmsg client — a fatal, fleet-wide wedge.
-	// dialSession's sessionsMx insertion is newest-session-wins, so a
-	// racing duplicate dial is replaced (and closed), not leaked.
-	return ce.dialSession(ctx, srvEntry)
+	// dialSessionOnce coalesces racing callers so the dial happens once.
+	return ce.dialSessionOnce(ctx, srvEntry)
+}
+
+// sessionDialFlight is one in-flight session dial to a server, shared by every
+// caller that asked for that server while it was running.
+type sessionDialFlight struct {
+	done chan struct{}
+	ses  ClientSession
+	err  error
+}
+
+// sessionDialFlightWait bounds how long a caller waits on someone else's dial
+// before dialing itself. A dial is bounded by DialTimeout plus the handshake,
+// so reaching this means the leader is stuck somewhere unforeseen; dialing
+// anyway is exactly today's behavior, which is a far better degradation than
+// blocking a caller forever.
+var sessionDialFlightWait = DialTimeout + 2*HandshakeTimeout
+
+// dialSessionOnce establishes a session to entry.Static, coalescing concurrent
+// callers so that exactly one dial per server is ever in flight.
+//
+// A duplicate dial is not merely wasted work, it is DESTRUCTIVE at both ends. A
+// dmsg server keeps one session per client PK, so the second session evicts the
+// first at the server (setSession, newest-session-wins) and the first dies with
+// a remote close; the client's own finishDialedSession then does the same to its
+// map, closing the predecessor it just handed to another caller. Both ends of a
+// live session — and every stream on it — are lost, and the Serve loop re-dials
+// the server it never lost.
+//
+// Nothing serialized these before: EnsureAndObtainSession re-checks the session
+// map and then dials WITHOUT holding sesMx (it must not hold it: the dial path
+// can re-enter session establishment through a self-hosted discovery and would
+// self-deadlock on a non-reentrant mutex), so N callers arriving together for a
+// server with no session all miss the check and all dial. The pinned-rendezvous
+// hostname in pkg/dmsgweb — <server-pk>.<dest-pk>.dmsg — is the way a user
+// reaches that: a browser opens several connections for one page and each one
+// dials the named server.
+//
+// The flight covers only the dial, never the discovery lookup that precedes it,
+// so the re-entrancy the sesMx comment warns about cannot land inside it:
+// dialSession does no lookups, and the entry-registration callback that can
+// re-enter runs AFTER the session is in the map, where the cache check
+// short-circuits. The bounded wait below is there in case that reasoning is
+// ever wrong: a caller degrades to today's duplicate dial rather than wedging.
+func (ce *Client) dialSessionOnce(ctx context.Context, entry *disc.Entry) (ClientSession, error) {
+	srvPK := entry.Static
+
+	ce.dialFlightMx.Lock()
+	if fl, ok := ce.dialFlight[srvPK]; ok {
+		ce.dialFlightMx.Unlock()
+		select {
+		case <-fl.done:
+			// The map is the truth: the leader's session may already have been
+			// replaced by a later reconnect while we waited.
+			if dSes, ok := ce.clientSession(ce.porter, srvPK); ok {
+				return dSes, nil
+			}
+			return fl.ses, fl.err
+		case <-ctx.Done():
+			return ClientSession{}, ctx.Err()
+		case <-time.After(sessionDialFlightWait):
+			// Fall through and dial: see sessionDialFlightWait.
+			return ce.dialSession(ctx, entry)
+		}
+	}
+	fl := &sessionDialFlight{done: make(chan struct{})}
+	if ce.dialFlight == nil {
+		ce.dialFlight = make(map[cipher.PubKey]*sessionDialFlight)
+	}
+	ce.dialFlight[srvPK] = fl
+	ce.dialFlightMx.Unlock()
+
+	fl.ses, fl.err = ce.dialSession(ctx, entry)
+
+	// Publish the result BEFORE dropping the flight, so a caller that grabs
+	// this flight in the instant between the two takes the finished result
+	// instead of becoming a second leader and dialing a duplicate.
+	close(fl.done)
+	ce.dialFlightMx.Lock()
+	if ce.dialFlight[srvPK] == fl {
+		delete(ce.dialFlight, srvPK)
+	}
+	ce.dialFlightMx.Unlock()
+
+	return fl.ses, fl.err
 }
 
 // EnsureSession ensures the existence of a session.
@@ -102,8 +186,10 @@ func (ce *Client) EnsureSession(ctx context.Context, entry *disc.Entry) error {
 	// Dial WITHOUT holding sesMx — same re-entrancy hazard as
 	// EnsureAndObtainSession: the dial path can re-enter session
 	// establishment via the self-hosted transport, which would
-	// self-deadlock on the non-reentrant sesMx.
-	_, err := ce.dialSession(ctx, &e)
+	// self-deadlock on the non-reentrant sesMx. Coalesced, so the Serve
+	// loop's dial and a caller's dial to the same server are one dial and
+	// not two sessions that evict each other.
+	_, err := ce.dialSessionOnce(ctx, &e)
 	return err
 }
 

--- a/pkg/dmsgweb/pinned_rendezvous_test.go
+++ b/pkg/dmsgweb/pinned_rendezvous_test.go
@@ -1,0 +1,132 @@
+// Package dmsgweb pkg/dmsgweb/pinned_rendezvous_test.go c4-app-web
+package dmsgweb
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/proxy"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// The pinned-rendezvous hostname — <server-pk>.<dest-pk>.dmsg — dials the
+// destination through a NAMED dmsg server instead of resolving it through
+// discovery, by ensuring a session to that server and dialing on it.
+//
+// Fetching one such host must not cost the proxy a live session. A page is
+// several requests, each is its own SOCKS5 CONNECT and its own dial of the
+// named server, and a dmsg server keeps one session per client PK: before the
+// dial coalescing in dmsg.dialSessionOnce every one of those dials built its own
+// session and evicted the one before it, so a hostname a user can simply type
+// tore down the session (and every stream on it) that the previous request was
+// using. Here that shows up as session-disconnect callbacks firing while the
+// fetches run.
+func TestSOCKS5PinnedRendezvous_ParallelFetchesKeepOneSession(t *testing.T) {
+	dc := disc.NewMock(0)
+
+	srvPK, srvSK := cipher.GenerateKeyPair()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := lis.Addr().String()
+	srv := dmsg.NewServer(srvPK, srvSK, dc, &dmsg.ServerConfig{MaxSessions: 20, UpdateInterval: 0}, nil)
+	srv.SetLogger(logging.MustGetLogger("pinned-srv"))
+	srvEntry := disc.NewServerEntry(srvPK, 0, addr, 20)
+	require.NoError(t, srvEntry.Sign(srvSK))
+	require.NoError(t, dc.PostEntry(t.Context(), srvEntry))
+	go func() { _ = srv.Serve(lis, addr) }() //nolint:errcheck
+	t.Cleanup(func() { _ = srv.Close() })    //nolint:errcheck
+
+	// The destination: an ordinary client on that server, serving HTTP on
+	// dmsg port 80.
+	destPK, destSK := cipher.GenerateKeyPair()
+	dest := dmsg.NewClient(destPK, destSK, dc, &dmsg.Config{MinSessions: 1})
+	dest.SetLogger(logging.MustGetLogger("pinned-dest"))
+	go dest.Serve(t.Context())             //nolint:errcheck
+	t.Cleanup(func() { _ = dest.Close() }) //nolint:errcheck
+	require.Eventually(t, func() bool { _, ok := dest.Session(srvPK); return ok },
+		20*time.Second, 100*time.Millisecond, "destination never formed a session")
+
+	dmsgLis, err := dest.Listen(80)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dmsgLis.Close() }) //nolint:errcheck
+	go func() {
+		_ = http.Serve(dmsgLis, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { //nolint:errcheck,gosec
+			fmt.Fprint(w, "pinned-ok") //nolint:errcheck
+		}))
+	}()
+
+	// The proxy's client. It is NOT served: the pinned dials below are the
+	// only dials it makes, so what the test observes is the pinned path and
+	// not a race with the client's own reconnect loop.
+	var disconnects atomic.Int64
+	proxyPK, proxySK := cipher.GenerateKeyPair()
+	proxyC := dmsg.NewClient(proxyPK, proxySK, dc, &dmsg.Config{
+		MinSessions: 1,
+		Callbacks: &dmsg.ClientCallbacks{
+			OnSessionDisconnect: func(_, _ string, _ error) { disconnects.Add(1) },
+		},
+	})
+	proxyC.SetLogger(logging.MustGetLogger("pinned-proxy"))
+	t.Cleanup(func() { _ = proxyC.Close() }) //nolint:errcheck
+
+	port := freePort(t)
+	cfg := Config{DomainSuffix: ".dmsg", ProxyPort: uint(port)}                                          //nolint:gosec
+	go func() { _ = serveSOCKS5Direct(t.Context(), logging.MustGetLogger("pinned-web"), proxyC, cfg) }() //nolint:errcheck
+	proxyAddr := fmt.Sprintf("127.0.0.1:%d", port)
+	waitForListen(t, proxyAddr)
+
+	host := fmt.Sprintf("http://%s.%s.dmsg/", srvPK.Hex(), destPK.Hex())
+	const fetches = 6
+	var (
+		wg     sync.WaitGroup
+		start  = make(chan struct{})
+		bodies = make([]string, fetches)
+		errs   = make([]error, fetches)
+	)
+	for i := 0; i < fetches; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// A transport each, so every fetch is its own CONNECT — what a
+			// browser does when it opens one page.
+			d, derr := proxy.SOCKS5("tcp", proxyAddr, nil, proxy.Direct)
+			if derr != nil {
+				errs[i] = derr
+				return
+			}
+			httpc := &http.Client{
+				Timeout:   20 * time.Second,
+				Transport: &http.Transport{Dial: d.Dial}, //nolint:staticcheck
+			}
+			<-start
+			resp, gerr := httpc.Get(host)
+			if gerr != nil {
+				errs[i] = gerr
+				return
+			}
+			defer resp.Body.Close() //nolint:errcheck
+			b, rerr := io.ReadAll(resp.Body)
+			errs[i], bodies[i] = rerr, string(b)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i := 0; i < fetches; i++ {
+		require.NoError(t, errs[i], "pinned fetch %d", i)
+		require.Equal(t, "pinned-ok", bodies[i], "pinned fetch %d", i)
+	}
+	require.Equal(t, 1, proxyC.SessionCount(), "the pinned fetches built more than one session to the named server")
+	require.Zero(t, disconnects.Load(), "a pinned fetch tore down a live session")
+}


### PR DESCRIPTION
`EnsureAndObtainSession` re-checks the session map and then dials without holding `sesMx` — it must not hold it, since the dial path can re-enter session establishment through a self-hosted discovery and would self-deadlock. So callers arriving together for a server with no session all miss the check and all dial. A dmsg server keeps one session per client PK, so each new session evicts the previous one at the server, and the client's own newest-session-wins registration closes it again locally: every racing caller but the last is left holding a session that was just closed from the far end.

The pinned-rendezvous hostname in `pkg/dmsgweb` — `<server-pk>.<dest-pk>.dmsg` — is how a user reaches that. One page is several requests, each is its own SOCKS5 CONNECT, and each dials the named server. Six parallel fetches dialled six sessions, failed with `session shutdown`, and cost the proxy a live session (and every stream on it) that the Serve loop then re-dialled.

This coalesces session establishment per server PK: one dial in flight, everyone else takes its result. The flight covers only the dial, not the discovery lookup before it, so the re-entrancy `sesMx` is released for cannot land inside it; a bounded wait degrades to the old duplicate dial rather than wedging if that reasoning is ever wrong. Two regression tests, both verified failing before the change: `TestEnsureAndObtainSession_CoalescesConcurrentDials` (6 concurrent callers got 6 distinct sessions) and `TestSOCKS5PinnedRendezvous_ParallelFetchesKeepOneSession` (parallel pinned fetches through the real SOCKS5 path).