### PR TITLE
fix(dmsg): a folded dmsg server advertises wss but nothing terminates the TLS

### DIFF
--- a/cmd/skywire-cli/commands/config/envfiles.go
+++ b/cmd/skywire-cli/commands/config/envfiles.go
@@ -151,6 +151,14 @@ const envfileLinux = `#
 #	whatever its listener resolves to, which is only right on a LAN.
 #DMSGSERVERPUBLIC='1.2.3.4:30084'
 
+#--	Where the in-visor dmsg server self-terminates TLS for its wss front
+#	via Let's Encrypt, so a browser or wasm visor can reach it. Set it on a
+#	host with NO reverse proxy — including any host where the standalone
+#	dmsg server used to be the thing serving :443, since folding it into the
+#	visor retired that listener. Leave it empty where Caddy (or another
+#	front) already owns :443.
+#DMSGSERVERWSTLS=':443'
+
 ### Rewards #############################################################
 
 #--	Skycoin reward address or xpub key

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -480,6 +480,8 @@ func init() {
 	genConfigCmd.Flags().BoolVar(&dmsgServerOwnKey, "dmsg-server", scriptExecBool("${DMSGSERVER:-false}"), "run a dmsg server inside the visor on the visor's OWN key, sharing its transport port")
 	gHiddenFlags = append(gHiddenFlags, "dmsg-server")
 	genConfigCmd.Flags().StringVar(&dmsgServerPublicAddr, "dmsg-server-public", scriptExecString("${DMSGSERVERPUBLIC}"), "address that in-visor dmsg server advertises (host:port); empty advertises whatever its listener resolves to")
+	genConfigCmd.Flags().StringVar(&dmsgServerWSTLSAddr, "dmsg-server-ws-tls", scriptExecString("${DMSGSERVERWSTLS}"), "address (\":443\") where the in-visor dmsg server self-terminates TLS for its wss front via Let's Encrypt; empty leaves TLS to a reverse proxy on this host")
+	gHiddenFlags = append(gHiddenFlags, "dmsg-server-ws-tls")
 	genConfigCmd.Flags().StringVar(&dmsgRelayAddr, "dmsg-relay-addr", scriptExecString("${DMSGRELAYADDR}"), "loopback host:port for the dmsg relay acceptor, for local services that cannot use the unix socket (a different user than the visor). Requires --dmsg-relay-keys")
 	genConfigCmd.Flags().StringVar(&dmsgRelayKeys, "dmsg-relay-keys", scriptExecString("${DMSGRELAYKEYS}"), "public keys allowed to attach to the dmsg relay, comma-separated. Required with --dmsg-relay-addr: a TCP listener has no filesystem gate")
 	genConfigCmd.Flags().BoolVar(&noDmsgRelay, "no-dmsg-relay", scriptExecBool("${NODMSGRELAY:-false}"), "do not serve the local dmsg relay acceptor at all (it is served by default)")
@@ -1518,6 +1520,7 @@ func configureLauncher(log *logging.Logger) {
 		conf.Dmsg.Server = &dmsgc.DmsgServerConfig{
 			Enabled:       true,
 			PublicAddress: dmsgServerPublicAddr,
+			WSTLSAddress:  dmsgServerWSTLSAddr,
 		}
 	}
 

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -211,6 +211,7 @@ var (
 	dmsgServerConf       string
 	dmsgServerOwnKey     bool
 	dmsgServerPublicAddr string
+	dmsgServerWSTLSAddr  string
 	dmsgRelayAddr        string
 	dmsgRelayKeys        string
 	dmsgWebSecretKey     string

--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -162,6 +162,7 @@ func collectSkyenvEdits(cmd *cobra.Command) []skyenvEdit {
 	addString("DMSGSERVERCONF", "dmsg-server-conf", autoconfigVals.DmsgServerConf)
 	addBool("DMSGSERVER", "dmsg-server", "no-dmsg-server", autoconfigVals.DmsgServer, autoconfigVals.NoDmsgServer)
 	addString("DMSGSERVERPUBLIC", "dmsg-server-public", autoconfigVals.DmsgServerPublic)
+	addString("DMSGSERVERWSTLS", "dmsg-server-ws-tls", autoconfigVals.DmsgServerWSTLS)
 
 	// Whitelists
 	addArray("DMSGPTYPKS", "dmsgpty-pks", autoconfigVals.DmsgptyPks)

--- a/pkg/dmsg/dmsgc/spec/spec.go
+++ b/pkg/dmsg/dmsgc/spec/spec.go
@@ -228,22 +228,21 @@ type DmsgServerConfig struct {
 	// how a host that ran `skywire dmsg server start <file>` as a separate
 	// unit folds that server into its visor (DMSGSERVERCONF in skywire.conf).
 	ConfigPath string `json:"config_path,omitempty"`
-	// WSTLSAddress is where the server SELF-TERMINATES TLS for its own
-	// wss:// host via Let's Encrypt, so the host needs no reverse proxy. Empty
-	// means ":443" whenever a wss URL is advertised at all — which is the
-	// address autocert's TLS-ALPN-01 challenge requires, and the one the
-	// standalone dmsg-server process this fold replaced was already using.
+	// WSTLSAddress, when set (":443"), makes the server SELF-TERMINATE TLS for
+	// its own wss:// host via Let's Encrypt, exactly as ws_tls_address does in a
+	// standalone dmsg-server config. Empty (the default) leaves TLS to an
+	// external front — which is the right answer on a host that already runs
+	// Caddy, and the wrong one on a host where the standalone dmsg server WAS
+	// the terminator, since folding it retired the only listener on :443.
+	// Requires :443, where autocert's TLS-ALPN-01 challenge is answered.
 	// Binding is best-effort: if something else owns the address the server
-	// logs and carries on with an external front. Set DisableWSTLS to opt out.
+	// logs and carries on with the external front.
 	WSTLSAddress string `json:"ws_tls_address,omitempty"`
 	// WSTLSCacheDir is the on-disk autocert certificate cache. Empty means
-	// "dmsg-autocert" beside the visor config file — where the standalone
-	// server kept it, so a folded server reuses the certificate it already has
+	// "dmsg-autocert" beside the visor config file — where a folded standalone
+	// server kept it, so the server reuses the certificate it already has
 	// instead of asking Let's Encrypt for a fresh one.
 	WSTLSCacheDir string `json:"ws_tls_cache_dir,omitempty"`
-	// DisableWSTLS opts out of the built-in TLS listener above, for a host
-	// that fronts the server with its own reverse proxy.
-	DisableWSTLS bool `json:"disable_ws_tls,omitempty"`
 }
 
 // MarshalJSON and UnmarshalJSON live in spec_native.go under

--- a/pkg/dmsg/dmsgc/spec/spec.go
+++ b/pkg/dmsg/dmsgc/spec/spec.go
@@ -228,6 +228,22 @@ type DmsgServerConfig struct {
 	// how a host that ran `skywire dmsg server start <file>` as a separate
 	// unit folds that server into its visor (DMSGSERVERCONF in skywire.conf).
 	ConfigPath string `json:"config_path,omitempty"`
+	// WSTLSAddress is where the server SELF-TERMINATES TLS for its own
+	// wss:// host via Let's Encrypt, so the host needs no reverse proxy. Empty
+	// means ":443" whenever a wss URL is advertised at all — which is the
+	// address autocert's TLS-ALPN-01 challenge requires, and the one the
+	// standalone dmsg-server process this fold replaced was already using.
+	// Binding is best-effort: if something else owns the address the server
+	// logs and carries on with an external front. Set DisableWSTLS to opt out.
+	WSTLSAddress string `json:"ws_tls_address,omitempty"`
+	// WSTLSCacheDir is the on-disk autocert certificate cache. Empty means
+	// "dmsg-autocert" beside the visor config file — where the standalone
+	// server kept it, so a folded server reuses the certificate it already has
+	// instead of asking Let's Encrypt for a fresh one.
+	WSTLSCacheDir string `json:"ws_tls_cache_dir,omitempty"`
+	// DisableWSTLS opts out of the built-in TLS listener above, for a host
+	// that fronts the server with its own reverse proxy.
+	DisableWSTLS bool `json:"disable_ws_tls,omitempty"`
 }
 
 // MarshalJSON and UnmarshalJSON live in spec_native.go under

--- a/pkg/services/dmsgsrv/dmsgsrv.go
+++ b/pkg/services/dmsgsrv/dmsgsrv.go
@@ -14,7 +14,6 @@ package dmsgsrv
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -30,7 +29,6 @@ import (
 
 	chi "github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
-	"golang.org/x/crypto/acme/autocert"
 
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/buildinfo"
@@ -378,13 +376,10 @@ func (s *service) Run(ctx context.Context) error {
 
 	// Built-in wss (opt-in via ws_tls_address): self-terminate TLS for this
 	// server's own <DNSLabel>.<suffix> host via Let's Encrypt autocert, so a dmsg
-	// host needs NO external reverse proxy (Caddy). It only ADDS a TLS listener —
-	// the plain-ws main port and the wss advert (mainWSURL) are unchanged — so it
-	// coexists with the Caddy-fronts-it path. If the address can't be bound (Caddy
-	// or another dmsg server on the host already owns :443) we log and skip, and
-	// the external-front path stands. Best-effort: a failure here never stops the
-	// server. Requires :443 (autocert's TLS-ALPN-01 challenge runs on the serving
-	// port); a host with >1 dmsg server, or that already serves :443, uses Caddy.
+	// host needs NO external reverse proxy (Caddy). See ServeWSTLS — best-effort,
+	// a bind failure leaves the external-front path standing. Requires :443
+	// (autocert's TLS-ALPN-01 challenge runs on the serving port); a host with
+	// >1 dmsg server, or that already serves :443, uses Caddy.
 	if cfg.WSTLSAddress != "" {
 		if wssHost == "" {
 			log.Warn("dmsg-ws-tls: ws_tls_address set but no wss host derivable (need wss_domain_suffix or a known fleet PK) — skipping built-in TLS")
@@ -396,22 +391,7 @@ func (s *service) Run(ctx context.Context) error {
 					cacheDir = filepath.Join(filepath.Dir(cfg.Path), "dmsg-autocert")
 				}
 			}
-			acm := &autocert.Manager{
-				Prompt:     autocert.AcceptTOS,
-				HostPolicy: autocert.HostWhitelist(wssHost),
-				Cache:      autocert.DirCache(cacheDir),
-			}
-			if tlsLis, terr := tls.Listen("tcp", cfg.WSTLSAddress, acm.TLSConfig()); terr != nil {
-				log.WithError(terr).Warnf("dmsg-ws-tls: cannot bind %s (a reverse proxy or another dmsg server may own it) — leaving TLS to an external front (Caddy)", cfg.WSTLSAddress)
-			} else {
-				log.WithField("ws_url", mainWSURL).WithField("tls_addr", cfg.WSTLSAddress).WithField("cache", cacheDir).
-					Infof("dmsg-ws-tls: self-terminating wss for %s via Let's Encrypt — no reverse proxy needed", wssHost)
-				go func() {
-					if err := srv.ServeWS(tlsLis, mainWSURL); err != nil {
-						log.Errorf("dmsg-ws-tls ServeWS: %v", err)
-					}
-				}()
-			}
+			ServeWSTLS(log, srv, cfg.WSTLSAddress, cacheDir, wssHost, mainWSURL)
 		}
 	}
 

--- a/pkg/services/dmsgsrv/wstls.go
+++ b/pkg/services/dmsgsrv/wstls.go
@@ -1,0 +1,54 @@
+// Package dmsgsrv pkg/services/dmsgsrv/wstls.go c2-vis-appsvc
+//
+// Built-in wss: a dmsg server self-terminating TLS for its own
+// <DNSLabel>.<suffix> host via Let's Encrypt, so a dmsg host needs no
+// external reverse proxy. Shared by the standalone service (Run) and by
+// the server a visor folds in on its own key (pkg/visor) — the fold
+// moved the WS front onto the visor's transport port but left the TLS
+// listener behind with the process that used to own it.
+package dmsgsrv
+
+import (
+	"crypto/tls"
+	"net"
+
+	"golang.org/x/crypto/acme/autocert"
+
+	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// ServeWSTLS terminates TLS for wssHost on addr with an autocert-managed
+// certificate cached in cacheDir, and serves dmsg-over-WebSocket there,
+// advertising advertisedWSURL. It only ADDS a listener: the plain-ws port and
+// the wss advert are untouched, so it coexists with an external front.
+//
+// Best-effort by design. If addr cannot be bound (a reverse proxy or another
+// dmsg server on the host already owns it) this logs and returns nil, leaving
+// the external-front path standing rather than failing startup. Requires the
+// address autocert's TLS-ALPN-01 challenge runs on, i.e. :443.
+//
+// The returned listener is the caller's to close; nil means nothing was bound.
+func ServeWSTLS(log *logging.Logger, srv *dmsg.Server, addr, cacheDir, wssHost, advertisedWSURL string) net.Listener {
+	if addr == "" || wssHost == "" || cacheDir == "" {
+		return nil
+	}
+	acm := &autocert.Manager{
+		Prompt:     autocert.AcceptTOS,
+		HostPolicy: autocert.HostWhitelist(wssHost),
+		Cache:      autocert.DirCache(cacheDir),
+	}
+	tlsLis, err := tls.Listen("tcp", addr, acm.TLSConfig())
+	if err != nil {
+		log.WithError(err).Warnf("dmsg-ws-tls: cannot bind %s (a reverse proxy or another dmsg server may own it) — leaving TLS to an external front", addr)
+		return nil
+	}
+	log.WithField("ws_url", advertisedWSURL).WithField("tls_addr", addr).WithField("cache", cacheDir).
+		Infof("dmsg-ws-tls: self-terminating wss for %s via Let's Encrypt — no reverse proxy needed", wssHost)
+	go func() {
+		if serr := srv.ServeWS(tlsLis, advertisedWSURL); serr != nil {
+			log.Errorf("dmsg-ws-tls ServeWS: %v", serr)
+		}
+	}()
+	return tlsLis
+}

--- a/pkg/services/dmsgsrv/wstls_test.go
+++ b/pkg/services/dmsgsrv/wstls_test.go
@@ -1,0 +1,46 @@
+// Package dmsgsrv pkg/services/dmsgsrv/wstls_test.go c2-vis-appsvc
+package dmsgsrv
+
+import (
+	"net"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// TestServeWSTLS_SkipsWithoutAHostOrAddress: the built-in TLS front is
+// meaningless without a host to get a certificate for, so it must decline
+// rather than bind a listener that can never complete a handshake.
+func TestServeWSTLS_SkipsWithoutAHostOrAddress(t *testing.T) {
+	log := logging.MustGetLogger("wstls_test")
+	for _, tc := range []struct{ name, addr, cache, host string }{
+		{"no address", "", "cache", "a.example.com"},
+		{"no host", "127.0.0.1:0", "cache", ""},
+		{"no cache dir", "127.0.0.1:0", "", "a.example.com"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if lis := ServeWSTLS(log, nil, tc.addr, tc.cache, tc.host, "wss://a.example.com/dmsg"); lis != nil {
+				_ = lis.Close() //nolint:errcheck
+				t.Fatal("bound a listener that cannot serve a certificate")
+			}
+		})
+	}
+}
+
+// TestServeWSTLS_UnbindableAddressIsNotFatal: a host whose :443 already
+// belongs to a reverse proxy must keep running with that external front,
+// not lose its dmsg server. The nil return is what tells the caller there
+// is nothing to close.
+func TestServeWSTLS_UnbindableAddressIsNotFatal(t *testing.T) {
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer occupied.Close() //nolint:errcheck
+
+	log := logging.MustGetLogger("wstls_test")
+	if lis := ServeWSTLS(log, nil, occupied.Addr().String(), t.TempDir(), "a.example.com", "wss://a.example.com/dmsg"); lis != nil {
+		_ = lis.Close() //nolint:errcheck
+		t.Fatal("bound an address another process already owns")
+	}
+}

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -155,6 +155,14 @@ type Values struct {
 	// DMSGSERVERPUBLIC.
 	DmsgServerPublic string
 
+	// DmsgServerWSTLS is where that server self-terminates TLS for its wss
+	// front (":443") instead of leaving it to a reverse proxy on the host —
+	// writes DMSGSERVERWSTLS. Which is right differs per host: some already
+	// run Caddy on :443, and on the rest the standalone dmsg server WAS the
+	// terminator, so folding it left the advertised wss front with nothing
+	// listening behind it.
+	DmsgServerWSTLS string
+
 	// DmsgRelayAddr is a loopback host:port for the local dmsg relay acceptor —
 	// writes DMSGRELAYADDR. The unix socket is served by default and needs no
 	// config, but it carries the VISOR's uid at 0600, so a service running as a
@@ -341,6 +349,7 @@ func New(v *Values) *cobra.Command {
 	cmd.Flags().BoolVar(&v.DmsgServer, "dmsg-server", false, "run a dmsg server inside the visor on the VISOR's OWN key, sharing --transport-port (one identity, one discovery entry, one forwarded port). Pin --transport-port to a port reachable from outside. Ignored when --dmsg-server-conf is set — writes DMSGSERVER in skywire.conf")
 	cmd.Flags().BoolVar(&v.NoDmsgServer, "no-dmsg-server", false, "stop running a dmsg server inside the visor — writes DMSGSERVER=false in skywire.conf")
 	cmd.Flags().StringVar(&v.DmsgServerPublic, "dmsg-server-public", "", "host:port the in-visor dmsg server advertises; empty advertises whatever its listener resolves to, which is only right on a LAN — writes DMSGSERVERPUBLIC in skywire.conf")
+	cmd.Flags().StringVar(&v.DmsgServerWSTLS, "dmsg-server-ws-tls", "", "address (\":443\") where the in-visor dmsg server self-terminates TLS for its wss front via Let's Encrypt; empty leaves TLS to a reverse proxy on this host — writes DMSGSERVERWSTLS in skywire.conf")
 	cmd.Flags().StringVar(&v.DmsgRelayAddr, "dmsg-relay-addr", "", "loopback host:port for the local dmsg relay acceptor, for services that run as a different user than the visor and so cannot open its 0600 unix socket. Requires --dmsg-relay-keys — writes DMSGRELAYADDR in skywire.conf")
 	cmd.Flags().StringVar(&v.DmsgRelayKeys, "dmsg-relay-keys", "", "public keys allowed to attach to the dmsg relay, comma-separated. Required with --dmsg-relay-addr: a TCP acceptor has no filesystem gate — writes DMSGRELAYKEYS in skywire.conf")
 	cmd.Flags().BoolVar(&v.NoDmsgRelay, "no-dmsg-relay", false, "do not serve the local dmsg relay acceptor at all (served by default) — writes NODMSGRELAY in skywire.conf")

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -1049,15 +1049,10 @@ func dmsgOnlyDisc(dmsgC *dmsg.Client, discPK cipher.PubKey, log *logging.Logger)
 // server without a redundant transit client. The client-side self-session
 // guard (SkipSelfServer, wired in dmsgc.New) keeps v.dmsgC from dialing this
 // co-resident server.
-// Defaults for the folded dmsg server's built-in wss listener. :443 is not
-// a preference — it is where autocert's TLS-ALPN-01 challenge has to be
-// answered, and where the standalone dmsg-server this fold replaced already
-// listened. The cache dir sits beside the visor config for the same reason:
-// it is where that server kept its certificate.
-const (
-	defaultDmsgWSTLSAddress  = ":443"
-	defaultDmsgWSTLSCacheDir = "dmsg-autocert"
-)
+// dmsgWSTLSCacheDirName is where a folded dmsg server keeps its autocert
+// certificate cache when ws_tls_cache_dir is unset: beside the visor config,
+// which is where the standalone server this fold replaced already kept it.
+const dmsgWSTLSCacheDirName = "dmsg-autocert"
 
 func initDmsgServer(ctx context.Context, v *Visor, log *logging.Logger) error {
 	if v.conf.Dmsg == nil || v.conf.Dmsg.Server == nil || !v.conf.Dmsg.Server.Enabled {
@@ -1160,23 +1155,21 @@ func initDmsgServer(ctx context.Context, v *Visor, log *logging.Logger) error {
 			log.WithField("ws_url", wssURL).
 				Info("Serving dmsg over WebSocket on the shared transport port")
 
-			// ...and the TLS that makes that URL dialable. The advert is
-			// wss://, and on these hosts the terminator was never a reverse
-			// proxy — it was the standalone dmsg-server's own autocert
-			// listener on :443, which the fold retired along with the process
-			// that owned it. So restoring the WS route alone left every folded
-			// server advertising a wss front that refuses the connection.
-			// Same listener, same certificate cache, now owned by the visor.
-			if !srvCfg.DisableWSTLS {
-				tlsAddr := srvCfg.WSTLSAddress
-				if tlsAddr == "" {
-					tlsAddr = defaultDmsgWSTLSAddress
-				}
+			// ...and, where the host has no front of its own, the TLS that
+			// makes that URL dialable. Whether one exists differs per host:
+			// some already run Caddy on :443, and on the rest the terminator
+			// was the standalone dmsg-server's OWN autocert listener, which
+			// the fold retired along with the process that owned it. So
+			// restoring the WS route alone left those hosts advertising a wss
+			// front that refuses the connection. ws_tls_address says which
+			// kind of host this is, exactly as it does in a standalone
+			// dmsg-server config; empty keeps the external front.
+			if tlsAddr := srvCfg.WSTLSAddress; tlsAddr != "" {
 				cacheDir := srvCfg.WSTLSCacheDir
 				if cacheDir == "" {
-					cacheDir = defaultDmsgWSTLSCacheDir
+					cacheDir = dmsgWSTLSCacheDirName
 					if p := v.conf.Path(); p != "" {
-						cacheDir = filepath.Join(filepath.Dir(p), defaultDmsgWSTLSCacheDir)
+						cacheDir = filepath.Join(filepath.Dir(p), dmsgWSTLSCacheDirName)
 					}
 				}
 				if tlsLis := dmsgsrv.ServeWSTLS(log, srv, tlsAddr, cacheDir, wssHost, wssURL); tlsLis != nil {

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -1049,6 +1049,16 @@ func dmsgOnlyDisc(dmsgC *dmsg.Client, discPK cipher.PubKey, log *logging.Logger)
 // server without a redundant transit client. The client-side self-session
 // guard (SkipSelfServer, wired in dmsgc.New) keeps v.dmsgC from dialing this
 // co-resident server.
+// Defaults for the folded dmsg server's built-in wss listener. :443 is not
+// a preference — it is where autocert's TLS-ALPN-01 challenge has to be
+// answered, and where the standalone dmsg-server this fold replaced already
+// listened. The cache dir sits beside the visor config for the same reason:
+// it is where that server kept its certificate.
+const (
+	defaultDmsgWSTLSAddress  = ":443"
+	defaultDmsgWSTLSCacheDir = "dmsg-autocert"
+)
+
 func initDmsgServer(ctx context.Context, v *Visor, log *logging.Logger) error {
 	if v.conf.Dmsg == nil || v.conf.Dmsg.Server == nil || !v.conf.Dmsg.Server.Enabled {
 		return nil
@@ -1136,18 +1146,43 @@ func initDmsgServer(ctx context.Context, v *Visor, log *logging.Logger) error {
 	// were left with just the hosts that had never been folded.
 	//
 	// The port is unchanged by the fold (transport_port is pinned to the port
-	// the server already used), so the existing DNS record and TLS front still
-	// point at the right place. Only the routing was missing.
+	// the server already used), so the DNS record still points at the right
+	// place — but the TLS front did NOT survive it; see below.
 	if shared && v.dmsgWSFactory != nil {
 		suffix := strings.TrimPrefix(deployment.Prod.WSSDomainSuffix, ".")
 		// Gate on the deployment knowing this key, exactly as the standalone
 		// service does: a third party running this binary must never advertise
 		// the deployment's domain for a PK with no DNS record.
 		if suffix != "" && deployment.Prod.IsKnownDmsgServer(v.conf.PK) {
-			wssURL := "wss://" + v.conf.PK.DNSLabel() + "." + suffix + "/dmsg"
+			wssHost := v.conf.PK.DNSLabel() + "." + suffix
+			wssURL := "wss://" + wssHost + "/dmsg"
 			v.dmsgWSFactory.SetDmsgWSHandler(srv.WSHandler(wssURL))
 			log.WithField("ws_url", wssURL).
 				Info("Serving dmsg over WebSocket on the shared transport port")
+
+			// ...and the TLS that makes that URL dialable. The advert is
+			// wss://, and on these hosts the terminator was never a reverse
+			// proxy — it was the standalone dmsg-server's own autocert
+			// listener on :443, which the fold retired along with the process
+			// that owned it. So restoring the WS route alone left every folded
+			// server advertising a wss front that refuses the connection.
+			// Same listener, same certificate cache, now owned by the visor.
+			if !srvCfg.DisableWSTLS {
+				tlsAddr := srvCfg.WSTLSAddress
+				if tlsAddr == "" {
+					tlsAddr = defaultDmsgWSTLSAddress
+				}
+				cacheDir := srvCfg.WSTLSCacheDir
+				if cacheDir == "" {
+					cacheDir = defaultDmsgWSTLSCacheDir
+					if p := v.conf.Path(); p != "" {
+						cacheDir = filepath.Join(filepath.Dir(p), defaultDmsgWSTLSCacheDir)
+					}
+				}
+				if tlsLis := dmsgsrv.ServeWSTLS(log, srv, tlsAddr, cacheDir, wssHost, wssURL); tlsLis != nil {
+					v.pushCloseStack("dmsg_server_wss", tlsLis.Close)
+				}
+			}
 		}
 	}
 	v.dmsgSrv.Store(srv)


### PR DESCRIPTION
Follow-up to #4833. That PR restored the WebSocket route a folded dmsg server lost, but assumed the TLS front in front of it had survived the fold. On some hosts it had not: the terminator there was never a reverse proxy, it was the standalone dmsg-server’s own autocert listener on `:443` (`ws_tls_address`), which the fold retired along with the process that owned it. So a folded server advertises `wss://<label>.<suffix>/dmsg` and the connection is refused:

```
✗ 02a2d4c346dabd165fd555dfdba4a7f4d18786fe7e055e562397cd5102bdd7f8dd  45.79.124.73:30082
  wss://akrnjq2g3k6rmx6vkxp5xjfh6tiypbx6pycv4vrds7gvcav5274n2.theskywirenetwork.net/dmsg:
  dial tcp 45.79.124.73:443: connect: connection refused
```

Nothing is listening on `:443` there and no reverse proxy is installed — the certificate for that host is still in `/opt/skywire/dmsg-autocert`, unused since the fold.

Which kind of host it is varies, so this is a knob rather than a default: `ws_tls_address` on the visor’s dmsg server config, with the same name and the same meaning it has in a standalone dmsg-server config — empty leaves TLS to the reverse proxy that already owns `:443`, `":443"` self-terminates. `ServeWSTLS` moves out of the standalone service’s `Run` into its own file so both call one implementation. `ws_tls_cache_dir` defaults to `dmsg-autocert` beside the visor config, where a folded server’s certificate already is, so it is reused rather than reissued. Binding stays best-effort: if something else owns the address the server logs and carries on.

`DMSGSERVERWSTLS` carries it in `skywire.conf`, so setting it on a packaged host survives the next autoconfig run.

Tests cover the two ways the helper must decline rather than bind: no host or cache to get a certificate for, and an address another process already owns.