### PR TITLE
fix(dmsg): a pinned rendezvous must not require a session the guest can't hold

### DIFF
--- a/pkg/dmsg/dmsg/client_dial.go
+++ b/pkg/dmsg/dmsg/client_dial.go
@@ -868,3 +868,36 @@ func (ce *Client) closeIfDialed(srvPK cipher.PubKey, ses ClientSession, hadBefor
 		ce.log.WithError(err).WithField("server_pk", srvPK).Warn("Failed to close session")
 	}
 }
+
+// DialStreamVia dials addr through a PINNED rendezvous server: it establishes a
+// session to serverPK and dials the destination over that session. This is how
+// a browser reaches a direct or hidden client by naming the server it sits on
+// — <server-pk>.<dest-pk>.dmsg — when the destination's own entry names no
+// server the dialer can use.
+//
+// A relay-attached client cannot do that, and should not have to. It holds one
+// session, the relay, and an empty discovery by construction (see
+// dmsgclient.StartDmsgLocalRelay), so EnsureAndObtainSession(serverPK) fails
+// the entry lookup with error 100 whichever server is named — there is no
+// address for it to dial. But a pin is not a demand for a particular session;
+// it is the caller saying where the destination can be found. A relay answers
+// that question better: DialStream tries relay sessions before any lookup, the
+// relay resolves the destination with the visor's entry cache and forwards over
+// the visor's own sessions, and since #4829 it can deliver over a terminal
+// skynet leg straight to the destination visor. Falling through to the ordinary
+// ladder honors the pin's intent rather than failing on its mechanism.
+//
+// With no relay the pin stays binding: the caller named a server deliberately
+// and nothing here knows better.
+func (ce *Client) DialStreamVia(ctx context.Context, serverPK cipher.PubKey, addr Addr) (*Stream, error) {
+	ses, err := ce.EnsureAndObtainSession(ctx, serverPK)
+	if err == nil {
+		return ses.DialStream(ctx, addr)
+	}
+	if len(ce.sortedRelaySessions()) == 0 {
+		return nil, fmt.Errorf("pin via dmsg server %s: %w", serverPK, err)
+	}
+	ce.log.WithError(err).WithField("server", serverPK).WithField("remote_pk", addr.PK).
+		Debug("No session to the pinned server; dialing over the relay, which resolves the destination itself.")
+	return ce.DialStream(ctx, addr)
+}

--- a/pkg/dmsg/dmsg/dial_via_test.go
+++ b/pkg/dmsg/dmsg/dial_via_test.go
@@ -1,0 +1,107 @@
+// Package dmsg pkg/dmsg/dmsg/dial_via_test.go c1-net-dmsg
+package dmsg
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// TestDialStreamVia_PinIsBindingWithoutARelay: a client that holds its own
+// server sessions asked for a specific rendezvous server. Nothing here knows
+// better than the caller, so an unresolvable pin must surface as the pin
+// failing — not quietly become an ordinary dial through some other server.
+func TestDialStreamVia_PinIsBindingWithoutARelay(t *testing.T) {
+	c, _ := newLocalRelayTestClient(t, "pin-no-relay", false, 0)
+	defer c.Close() //nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	pinned, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+
+	_, err := c.DialStreamVia(ctx, pinned, Addr{PK: dst, Port: 80})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "pin via dmsg server")
+	require.Contains(t, err.Error(), pinned.String())
+}
+
+// TestDialStreamVia_RelayAttachedFallsThroughToTheRelay is the guest-404
+// regression. An attached client's discovery is empty by construction, so
+// EnsureAndObtainSession on the pinned server can only ever fail the entry
+// lookup — which made every pinned-rendezvous hostname
+// (<server-pk>.<dest-pk>.dmsg) unusable from a process attached to its visor,
+// including the survey resolving proxy.
+//
+// The pin says where the destination can be found; the relay already knows,
+// and reaches it. So the dial must succeed through the relay rather than fail
+// on a session the guest was never going to hold.
+func TestDialStreamVia_RelayAttachedFallsThroughToTheRelay(t *testing.T) {
+	sock := shortSocketPath(t)
+	lis, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+
+	relay, _ := newLocalRelayTestClient(t, "pin-acceptor", false, DefaultClientMaxRelayedStreams)
+	defer relay.Close() //nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	go func() {
+		_ = relay.ServeLocalRelay(ctx, lis, 70, nil) //nolint:errcheck
+	}()
+
+	attach := func(name string) (*Client, cipher.PubKey) {
+		t.Helper()
+		c, pk := newLocalRelayTestClient(t, name, true, 0)
+		t.Cleanup(func() { _ = c.Close() }) //nolint:errcheck
+		_, aerr := c.AttachLocalRelay(ctx, "unix", sock)
+		require.NoError(t, aerr)
+		go c.Serve(ctx)
+		select {
+		case <-c.Ready():
+		case <-ctx.Done():
+			t.Fatalf("%s never attached", name)
+		}
+		return c, pk
+	}
+
+	dst, dstPK := attach("pin-dst")
+	src, srcPK := attach("pin-src")
+
+	dstLis, err := dst.Listen(80)
+	require.NoError(t, err)
+
+	accepted := make(chan cipher.PubKey, 1)
+	go func() {
+		s, aerr := dstLis.AcceptStream()
+		if aerr != nil {
+			close(accepted)
+			return
+		}
+		accepted <- s.RawRemoteAddr().PK
+		_ = s.Close() //nolint:errcheck
+	}()
+
+	// A server PK in no discovery — which, for an attached client, is every
+	// server PK: its discovery has no entries at all.
+	pinned, _ := cipher.GenerateKeyPair()
+
+	stream, err := src.DialStreamVia(ctx, pinned, Addr{PK: dstPK, Port: 80})
+	require.NoError(t, err, "the relay reaches the destination; the pin must not block that")
+	defer stream.Close() //nolint:errcheck
+	require.Equal(t, dstPK, stream.RawRemoteAddr().PK)
+
+	select {
+	case pk, ok := <-accepted:
+		require.True(t, ok, "destination failed to accept")
+		require.Equal(t, srcPK, pk, "the destination must see the attached client's own key")
+	case <-ctx.Done():
+		t.Fatal("destination never accepted the stream")
+	}
+}

--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -505,11 +505,11 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 					}
 					serverPK := rl.PK
 					log.WithField("server", serverPK).WithField("port", port).Debug("SOCKS5 → DMSG pinned via server")
-					ses, serr := dmsgC.EnsureAndObtainSession(ctx, serverPK)
-					if serr != nil {
-						return nil, fmt.Errorf("pin via dmsg server %s: %w", serverPK, serr)
-					}
-					str, derr := ses.DialStream(ctx, dstAddr)
+					// DialStreamVia, not EnsureAndObtainSession + DialStream:
+					// a relay-attached client has no discovery to resolve the
+					// pinned server's address with, and does not need one —
+					// its relay resolves the destination itself. See its doc.
+					str, derr := dmsgC.DialStreamVia(ctx, serverPK, dstAddr)
 					if derr != nil {
 						return nil, derr
 					}


### PR DESCRIPTION
A client attached to its visor’s local relay holds one session and an empty discovery by construction — that is what attaching *is* (see `dmsgclient.StartDmsgLocalRelay`). So `EnsureAndObtainSession(serverPK)` on a pinned rendezvous hostname `<server-pk>.<dest-pk>.dmsg` fails the entry lookup with

```
dmsg error 100 - entry is not found in discovery: status code: 404
```

for every server that could be named, and the pinned form is unusable from an attached process — including the survey resolving proxy, which is the kind of process attaching exists for.

But a pin is not a demand for a particular session. It is the caller saying *where the destination can be found*, and a relay answers that better: `DialStream` already tries relay sessions **before** any discovery lookup, the relay resolves the destination against the visor’s entry cache and forwards over the visor’s own sessions, and since #4829 it can deliver over a terminal skynet leg straight to the destination visor. `DialStreamVia` honors the pin’s intent by falling through to that ladder rather than failing on its mechanism.

With no relay the pin stays binding — the caller named a server deliberately and nothing here knows better than they do. Both halves are tested; the fallthrough test fails with the original error when the fallback is removed.