### PR TITLE
fix(transport): the dmsg WS handler was lost to a ClientFactory value copy

### DIFF
--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -114,7 +114,15 @@ type ClientFactory struct {
 	// dmsgWSHandler routes the dmsg-over-WebSocket path on the shared transport
 	// port. Held here rather than on the WS client because the client is built
 	// per MakeClient call while the co-resident dmsg server is wired once, later.
-	dmsgWSHandler atomic.Value
+	//
+	// It is a POINTER on purpose. A ClientFactory is passed around BY VALUE —
+	// visorcore.TransportManagerDeps.Factory and transport.NewManager both take
+	// one — so a bare atomic.Value here is copied, and the copy the WS client
+	// reads is not the one SetDmsgWSHandler writes to. The handler then never
+	// arrives and the /dmsg path 404s on every folded dmsg server. Sharing one
+	// allocation makes the copies agree. atomic.Value carries no noCopy, so go
+	// vet's copylocks cannot catch the mistake; this comment is the guard.
+	dmsgWSHandler *atomic.Value
 	// dmsgSharedListener is the tcpDemux branch carrying dmsg sessions, set
 	// only when ShareTCPWithDmsgServer was true at bind time.
 	dmsgSharedListener net.Listener
@@ -161,7 +169,7 @@ func (f *ClientFactory) MakeClient(netType types.Type, port int) (Client, error)
 		wc.(*wsClient).ar = f.ARClient // native: resolve ws:// from the stcpr AR record
 		if f.wsSharedListener != nil { // unified transport port
 			wc.(*wsClient).sharedListener = f.wsSharedListener
-			wc.(*wsClient).dmsgWS = &f.dmsgWSHandler
+			wc.(*wsClient).dmsgWS = f.dmsgWSHandler
 		}
 		return wc, nil
 	case types.WT:

--- a/pkg/transport/network/client_unified_tcp.go
+++ b/pkg/transport/network/client_unified_tcp.go
@@ -12,6 +12,7 @@ package network
 import (
 	"fmt"
 	"net"
+	"sync/atomic"
 )
 
 // EnableUnifiedTCP binds the master TCP listener on port and prepares the cmux
@@ -53,6 +54,9 @@ func (f *ClientFactory) bindTCPDemux(port int) error {
 	f.stcprSharedListener = d.STCPR()
 	f.wsSharedListener = d.WS()
 	f.dmsgSharedListener = d.DMSG()
+	// Allocate BEFORE any MakeClient call, so every copy of this factory shares
+	// the one the WS listener reads. See ClientFactory.dmsgWSHandler.
+	f.dmsgWSHandler = new(atomic.Value)
 	return nil
 }
 
@@ -95,7 +99,7 @@ func (f *ClientFactory) DmsgSharedListener() net.Listener { return f.dmsgSharedL
 // ARClient is. Called once the co-resident server is up; the WS client reads it
 // per request, so ordering does not matter.
 func (f *ClientFactory) SetDmsgWSHandler(h any) {
-	if f == nil || h == nil {
+	if f == nil || h == nil || f.dmsgWSHandler == nil {
 		return
 	}
 	f.dmsgWSHandler.Store(h)

--- a/pkg/transport/network/tcpdemux_dmsg_test.go
+++ b/pkg/transport/network/tcpdemux_dmsg_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"io"
 	"net"
+	"net/http"
 	"testing"
 	"time"
 
@@ -122,4 +123,41 @@ func TestClientFactory_DmsgSharedListener(t *testing.T) {
 	require.NotNil(t, shared)
 	require.Equal(t, on.stcprSharedListener.Addr().String(), shared.Addr().String(),
 		"the dmsg branch listens on the same port as stcpr")
+}
+
+// TestClientFactory_DmsgWSHandlerSurvivesAValueCopy is the regression for the
+// folded dmsg server's /dmsg path answering 404 on every host.
+//
+// A ClientFactory travels BY VALUE: visorcore.TransportManagerDeps.Factory and
+// transport.NewManager both take one, so the factory the WS client is built
+// from is a copy of the one the visor keeps a pointer to and later calls
+// SetDmsgWSHandler on. With the handler held as a bare atomic.Value the copy
+// got its own, the WS listener read that empty one forever, and the advertised
+// wss://<label>/dmsg URL resolved to a 404 — while every part looked wired.
+//
+// go vet's copylocks cannot see this: atomic.Value carries no noCopy. So the
+// invariant is asserted here instead.
+func TestClientFactory_DmsgWSHandlerSurvivesAValueCopy(t *testing.T) {
+	f := ClientFactory{ShareTCPWithDmsgServer: true}
+	require.NoError(t, f.EnableDefaultTCPDemux(0))
+	defer f.CloseUnifiedTCP() //nolint:errcheck
+
+	// cp stands in for the factory transport.NewManager holds and calls
+	// MakeClient on; f stands in for v.dmsgWSFactory.
+	cp := f
+	f.SetDmsgWSHandler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	require.NotNil(t, cp.dmsgWSHandler, "the copy must share the original's allocation")
+	got, ok := cp.dmsgWSHandler.Load().(http.Handler)
+	require.True(t, ok, "a handler set on the original must be visible through a copy")
+	require.NotNil(t, got)
+}
+
+// A factory with no shared TCP listener never allocates the handler slot, so
+// SetDmsgWSHandler must be a no-op rather than a nil dereference.
+func TestClientFactory_SetDmsgWSHandlerWithoutASharedListener(t *testing.T) {
+	var f ClientFactory
+	require.NotPanics(t, func() {
+		f.SetDmsgWSHandler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	})
 }


### PR DESCRIPTION
Follow-up to #4833 and #4836. #4833 routed the folded dmsg server’s `/dmsg` path on the shared transport port and the advertised wss URL went out — but the path answers **404 on every host that has it**. Measured on three production visors:

```
02a2d4c3… :30082  dmsg=426 root=426   (pre-#4833 build: no /dmsg route, catch-all answered)
02c48393… :30084  dmsg=404 root=426
0371ab4b… :30087  dmsg=404 root=426
```

A `ClientFactory` travels **by value** — `visorcore.TransportManagerDeps.Factory` and `transport.NewManager` both take one — so the factory `MakeClient` builds the WS client from is a *copy* of the one the visor stored a pointer to as `v.dmsgWSFactory`. With the handler held as a bare `atomic.Value` field, the copy got its own: `SetDmsgWSHandler` wrote to the original, the WS listener read the copy, and it stayed empty. Every part looked wired — including the advert, which `WSHandler` sets as a side effect of being called — while the URL it advertised served nothing.

Fix: hold one allocation and share it. The field becomes `*atomic.Value`, allocated in `bindTCPDemux` before any `MakeClient` call, so every copy refers to the same slot.

`go vet`’s copylocks cannot catch this — `atomic.Value` carries no `noCopy` — so the invariant is pinned by a test, which fails with exactly `a handler set on the original must be visible through a copy` when the pointer is reverted.

Worth noting for the record: before #4833, `/dmsg` fell through to the catch-all and was answered by the **WS transport** handler — a 426 that `cli mdisc check` accepted, from the wrong protocol. This path was never actually serving dmsg; it only stopped looking fine.